### PR TITLE
Supports uvloop event loop policy and divides test environment with tox

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import asyncio
+import pytest
+import os
+
+
+def pytest_cmdline_preparse(args):
+    loop_policy = os.environ.get('EVENT_LOOP')
+    if loop_policy:
+        args[:] = ['--loop-policy', loop_policy] + args
+
+def pytest_addoption(parser):
+    parser.addoption('--loop-policy', action='store',
+                     default=None, help='set event loop policy')
+
+
+def pytest_collection_modifyitems(config, items):
+    # TODO: We could skip some tests regarding the specific type of
+    # event loop policy.
+    loop_policy = config.getoption('--loop-policy')
+    if loop_policy == 'uvloop':
+        import uvloop
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        return
+    elif loop_policy == 'tokio':
+        # import tokio
+        # asyncio.set_event_loop_policy(tokio.EventLoopPolicy())
+        raise NotImplementedError('tokio module is not setup properly.')
+    return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,6 @@ import pytest
 import os
 
 
-def pytest_cmdline_preparse(args):
-    loop_policy = os.environ.get('EVENT_LOOP')
-    if loop_policy:
-        args[:] = ['--loop-policy', loop_policy] + args
-
 def pytest_addoption(parser):
     parser.addoption('--loop-policy', action='store',
                      default=None, help='set event loop policy')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 import asyncio
-import pytest
-import os
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,15 @@ def pytest_collection_modifyitems(config, items):
     # TODO: We could skip some tests regarding the specific type of
     # event loop policy.
     loop_policy = config.getoption('--loop-policy')
-    if loop_policy == 'uvloop':
+    if loop_policy == 'default' or not loop_policy:
+        asyncio.set_event_loop_policy(None)
+    elif loop_policy == 'uvloop':
         import uvloop
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-        return
     elif loop_policy == 'tokio':
         # import tokio
         # asyncio.set_event_loop_policy(tokio.EventLoopPolicy())
         raise NotImplementedError('tokio module is not setup properly.')
-    return
+    else:
+        raise NotImplementedError(f'{loop_policy} loop policy is not supported '
+                                   'for now.')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36-{uvloop,default}
+    py36-{default,uvloop}
 skipsdist = true
 
 [testenv]
@@ -11,10 +11,8 @@ deps =
     -rrequirements.txt
     -rrequirements-ci.txt
     py36-uvloop: uvloop
-setenv = 
-    uvloop: EVENT_LOOP=uvloop
 commands =
     pip install -f {distdir} -e ./
     flake8 ./aiotools/
-    pytest --basetemp={envtmpdir} -vv -s tests/
-
+    default: pytest --loop-policy=default -vv -s tests/
+    uvloop: pytest --loop-policy=uvloop -vv -s tests/

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ deps =
     six
     flake8
     pytest
-    -rrequirements.txt
     -rrequirements-ci.txt
     py36-uvloop: uvloop
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist =
+    py36-{uvloop,default}
+skipsdist = true
+
+[testenv]
+deps =
+    six
+    flake8
+    pytest
+    -rrequirements.txt
+    -rrequirements-ci.txt
+    py36-uvloop: uvloop
+setenv = 
+    uvloop: EVENT_LOOP=uvloop
+commands =
+    pip install -f {distdir} -e ./
+    flake8 ./aiotools/
+    pytest --basetemp={envtmpdir} -vv -s tests/
+


### PR DESCRIPTION
To configure event loop easily, I fixed `tests/conftest.py` to accept command line argument `--loop-policy`. Event loop policy is changed in `pytest_collection_modifyitems` and it works. But I'm not sure whether it is an anti-pattern or not.

Also, I wrote tox.ini to divide test environment by event loop policy. In this pull request, it supports uvloop. It is easy to extend with another 3rd party event loop policy: just adding environment and dependency and it's done.

However, it seems that tox does not handle UNIX signal properly. Currently sequential test does not work. We can temporarily add pytest command to `.travis.yml`, but I think it is not a good idea.

Feedbacks are always welcomed, thanks.