### PR TITLE
feat: Expose `process_index` context variable for server processes

### DIFF
--- a/changes/31.feature.md
+++ b/changes/31.feature.md
@@ -1,0 +1,1 @@
+**server**: Expose `process_index` context variable for worker processes

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -74,6 +74,9 @@ log = logging.getLogger(__name__)
 if _cv_available:
     process_index: 'contextvars.ContextVar[int]'
     process_index = contextvars.ContextVar('process_index')
+else:
+    # Unsupported in Python 3.6
+    process_index = None  # type: ignore  # noqa
 
 
 class InterruptedBySignal(BaseException):


### PR DESCRIPTION
This PR adds a context variable `process_idex` to the `aiotools.server` module so that the worker processes could read the index of current process anywhere.
