### PR TITLE
Support for `msg` arg to `cancel()` added in Python 3.9

### DIFF
--- a/changes/32.feature.md
+++ b/changes/32.feature.md
@@ -1,0 +1,1 @@
+Add support for Python 3.9's `msg` argument to `Task.cancel()`.

--- a/src/aiotools/taskgroup.py
+++ b/src/aiotools/taskgroup.py
@@ -220,9 +220,12 @@ class TaskGroup:
         # we need a flag to say if a task was cancelled or not.
         # We also need to be able to flip that flag.
 
-        def _task_cancel(task, orig_cancel):
+        def _task_cancel(task, orig_cancel, msg=None):
             task.__cancel_requested__ = True
-            return orig_cancel()
+            if msg is not None:
+                return orig_cancel(msg)
+            else:
+                return orig_cancel()
 
         if hasattr(task, '__cancel_requested__'):
             return

--- a/tests/test_taskgroup.py
+++ b/tests/test_taskgroup.py
@@ -176,7 +176,7 @@ async def test_cancel_parent_task(cancel_msg):
             tg.create_task(do_job())
 
     with VirtualClock().patch_loop():
-        parent_task = asyncio.create_task(parent())
+        parent_task = asyncio.ensure_future(parent())
         await asyncio.sleep(0.1)
         if cancel_msg == "MISSING":
             parent_task.cancel()

--- a/tests/test_taskgroup.py
+++ b/tests/test_taskgroup.py
@@ -173,7 +173,7 @@ async def test_cancel_parent_task(cancel_msg):
 
     async def parent():
         async with TaskGroup() as tg:
-            t1 = tg.create_task(do_job())
+            tg.create_task(do_job())
 
     with VirtualClock().patch_loop():
         parent_task = asyncio.create_task(parent())

--- a/tests/test_taskgroup.py
+++ b/tests/test_taskgroup.py
@@ -155,6 +155,38 @@ async def test_subtask_cancellation():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cancel_msg",
+    (
+        ["MISSING", None, "msg"]
+        if sys.version_info >= (3, 9, 0)
+        else ["MISSING"]
+    ),
+)
+async def test_cancel_parent_task(cancel_msg):
+
+    results = []
+
+    async def do_job():
+        await asyncio.sleep(1)
+        results.append('a')
+
+    async def parent():
+        async with TaskGroup() as tg:
+            t1 = tg.create_task(do_job())
+
+    with VirtualClock().patch_loop():
+        parent_task = asyncio.create_task(parent())
+        await asyncio.sleep(0.1)
+        if cancel_msg == "MISSING":
+            parent_task.cancel()
+        else:
+            parent_task.cancel(cancel_msg)
+        await asyncio.gather(parent_task, return_exceptions=True)
+        assert results == []
+
+
+@pytest.mark.asyncio
 async def test_taskgroup_error():
     with VirtualClock().patch_loop():
 


### PR DESCRIPTION
Python 3.9 added a `msg` arg to `cancel()`.  If the patched parent task of a task group is cancelled with this argument, we get this error:

```
TypeError: _task_cancel() takes 2 positional arguments but 3 were given
```

This adds a test for this scenario, and then fixes it by adding an optional argument to the wrapper.