### PR TITLE
Rewrite PersistentTaskgroup for Python 3.11

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha.6 - 3.11.0"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -5,12 +5,15 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11.0-alpha5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
       uses: actions/cache@v2
       with:
@@ -34,12 +37,15 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11.0-alpha5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
       uses: actions/cache@v2
       with:
@@ -66,7 +72,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11.0-alpha.5 - 3.11.0"]
+        python-version: ["3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11.0-alpha.5 - 3.11.0"]
+        python-version: ["3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11.0-alpha.6 - 3.11.0"]
+        python-version: ["3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11.0-alpha.6 - 3.11.0"]
+        python-version: ["3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11.0-alpha5 - 3.11.0"]
+        python-version: ["3.10", "3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11.0-alpha5 - 3.11.0"]
+        python-version: ["3.10", "3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha5 - 3.11.0"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha.5 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11.0-alpha.5 - 3.11.0"]
+        python-version: ["3.11.0-alpha.6 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11.0-alpha.5 - 3.11.0"]
+        python-version: ["3.11.0-alpha.6 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha.5 - 3.11.0"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha.6 - 3.11.0"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -59,6 +59,7 @@ jobs:
         python -m pip install -U pip setuptools
         python -m pip install -U -r requirements/typecheck.txt
     - name: Type check with mypy
+      continue-on-error: true
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then
           echo "(skipping matchers for pull request from local branches)"
@@ -66,10 +67,13 @@ jobs:
           echo "::add-matcher::.github/workflows/mypy-matcher.json"
         fi
         python -m mypy --no-color-output src/aiotools tests
+    - name: Allow failures
+      run: true
 
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha.5 - 3.11.0"]

--- a/changes/36.feature.md
+++ b/changes/36.feature.md
@@ -1,0 +1,1 @@
+Rewrite PersistentTaskGroup to use Python 3.11's latest additions such as `Task.uncancel()` and `Task.cancelling()` while still supporting older Python versions

--- a/docs/aiotools.taskgroup.rst
+++ b/docs/aiotools.taskgroup.rst
@@ -77,6 +77,13 @@ Task Group
    :meth:`loop.call_exception_handler() <asyncio.loop.call_exception_handler()>`
    as the last resort.
 
+   *exception_handler* should be an asynchronous function that accepts the
+   exception type, exception object, and the traceback, just like
+   ``__aexit__()`` dunder method.  The default handler just prints out the
+   exception log using :func:`traceback.print_exc()`.  Note that the
+   handler is invoked within the exception handling context and thus
+   :func:`sys.exc_info()` is also available.
+
    Since the exception handling and reporting takes places immediately, it
    eliminates potential arbitrary report delay due to other tasks or the execution
    method.  This resolves a critical debugging pain when only termination of the

--- a/docs/aiotools.taskgroup.rst
+++ b/docs/aiotools.taskgroup.rst
@@ -11,6 +11,11 @@ Task Group
    A :class:`contextvars.ContextVar` that has the reference to the current innermost
    :class:`TaskGroup` instance.  Available only in Python 3.7 or later.
 
+.. attribute:: current_ptaskgroup
+
+   A :class:`contextvars.ContextVar` that has the reference to the current innermost
+   :class:`PersistentTaskGroup` instance.  Available only in Python 3.7 or later.
+
 .. class:: TaskGroup(*, name=None)
 
    Provides a guard against a group of tasks spawend via its :meth:`create_task()`
@@ -41,6 +46,8 @@ Task Group
       cancellation before all nested spawned tasks start without context
       switches and propagation of the source exception when the context
       manager (parent task) is getting cancelled but continued.
+      All existing codes should run without any issues, but it is
+      recommended to test thoroughly.
 
 .. class:: PersistentTaskGroup(*, name=None, exception_handler=None)
 
@@ -67,7 +74,7 @@ Task Group
    Regardless how it is executed, it lets all spawned tasks run to their completion
    and calls the exception handler to report any unhandled exceptions immediately.
    If there are exceptions occurred again in the exception handlers, then it uses
-   :meth:`AbstractEventLoop.call_exception_handler() <asyncio.loop.call_exception_handler()>`
+   :meth:`loop.call_exception_handler() <asyncio.loop.call_exception_handler()>`
    as the last resort.
 
    Since the exception handling and reporting takes places immediately, it
@@ -99,6 +106,8 @@ Task Group
       Rewrote the overall implementation referring the Python 3.11 stdlib's
       :class:`asyncio.TaskGroup` implementation and adapting it to the
       semantics for "persistency".
+      All existing codes should run without any issues, but it is
+      recommended to test thoroughly.
 
 
 .. exception:: TaskGroupError

--- a/docs/aiotools.taskgroup.rst
+++ b/docs/aiotools.taskgroup.rst
@@ -1,6 +1,114 @@
 Task Group
 ==========
 
-.. automodule:: aiotools.taskgroup
-    :members:
-    :undoc-members:
+..
+   Since taskgroup dynamically imports the implementation classes
+   depending on the feature availability, documentations are gathered
+   to here to prevent duplication.
+
+.. attribute:: current_taskgroup
+
+   A :class:`contextvars.ContextVar` that has the reference to the current innermost
+   :class:`TaskGroup` instance.  Available only in Python 3.7 or later.
+
+.. class:: TaskGroup(*, name=None)
+
+   Provides a guard against a group of tasks spawend via its :meth:`create_task()`
+   method instead of the vanilla fire-and-forgetting :func:`asyncio.create_task()`.
+
+   See the motivation and rationale in `the trio's documentation
+   <https://trio.readthedocs.io/en/stable/reference-core.html#nurseries-and-spawning>`_.
+
+   In Python 3.11 or later, this wraps :class:`asyncio.TaskGroup` with a small
+   extension to set the current taskgroup in a context variable.
+
+   .. method:: create_task(coro, *, name=None)
+
+      Spawns a new task inside the taskgroup and returns the reference to
+      the task.  Setting the name of tasks is supported in Python 3.8 or
+      later only and ignored in older versions.
+
+   .. method:: get_name()
+
+      Returns the name set when creating the instance.
+
+   .. versionadded:: 1.0.0
+
+   .. versionchanged:: 1.5.0
+
+      Fixed edge-case bugs by referring the Python 3.11 stdlib's
+      :class:`asyncio.TaskGroup` implementation, including abrupt
+      cancellation before all nested spawned tasks start without context
+      switches and propagation of the source exception when the context
+      manager (parent task) is getting cancelled but continued.
+
+.. class:: PersistentTaskGroup(*, name=None, exception_handler=None)
+
+   Provides an abstraction of long-running task groups for server applications.
+   The main use case is to implement a dispatcher of async event handlers, to group
+   RPC/API request handlers, etc. with safe and graceful shutdown.
+   Here "long-running" means that all tasks should keep going even when sibling
+   tasks fail with unhandled errors and such errors must be reported immediately.
+   Here "safety" means that all spawned tasks should be reclaimed before exit or
+   shutdown.
+
+   When used as an async context manager, it works similarly to
+   :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
+   context scope when all tasks finish, just like :class:`asyncio.TaskGroup`, but
+   it does NOT abort when there are unhandled exceptions from child tasks; just
+   keeps sibling tasks running and reporting errors as they occur (see below).
+
+   When *not* used as an async context maanger (e.g., used as attributes of
+   long-lived objects), it persists running until :meth:`shutdown()` is called
+   explicitly.  Note that it is the user's responsibility to call
+   :meth:`shutdown()` because :class:`PersistentTaskGroup` does not provide the
+   ``__del__()`` method.
+
+   Regardless how it is executed, it lets all spawned tasks run to their completion
+   and calls the exception handler to report any unhandled exceptions immediately.
+   If there are exceptions occurred again in the exception handlers, then it uses
+   :meth:`AbstractEventLoop.call_exception_handler() <asyncio.loop.call_exception_handler()>`
+   as the last resort.
+
+   Since the exception handling and reporting takes places immediately, it
+   eliminates potential arbitrary report delay due to other tasks or the execution
+   method.  This resolves a critical debugging pain when only termination of the
+   application displays accumulated errors, as sometimes we don't want to terminate
+   but just inspect what is happening.
+
+   .. method:: create_task(coro, *, name=None)
+
+      Spawns a new task inside the taskgroup and returns the reference to
+      the task.  Setting the name of tasks is supported in Python 3.8 or
+      later only and ignored in older versions.
+
+   .. method:: get_name()
+
+      Returns the name set when creating the instance.
+
+   .. method:: shutdown()
+      :async:
+
+      Triggers immediate shutdown of this taskgroup, cancelling all
+      unfinished tasks and waiting for their completion.
+
+   .. versionadded:: 1.4.0
+
+   .. versionchanged:: 1.5.0
+
+      Rewrote the overall implementation referring the Python 3.11 stdlib's
+      :class:`asyncio.TaskGroup` implementation and adapting it to the
+      semantics for "persistency".
+
+
+.. exception:: TaskGroupError
+
+   Represents a collection of errors raised inside a task group.
+   Callers may iterate over the errors using the ``__errors__`` attribute.
+
+   In Python 3.11 or later, this is a mere wrapper of underlying
+   :exc:`BaseExceptionGroup`.  This allows existing user codes to run
+   without modification while users can take advantage of the new
+   ``except*`` syntax and :exc:`ExceptionGroup` methods if they use Python
+   3.11 or later.  Note that if none of the passed exceptions passed is a
+   :exc:`BaseException`, it automatically becomes :exc:`ExceptionGroup`.

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -7,7 +7,6 @@ from . import (
     iter as _iter,
     server,
     taskgroup,
-    ptaskgroup,
     timer,
 )
 
@@ -26,7 +25,6 @@ __all__ = (
     *_iter.__all__,
     *server.__all__,
     *taskgroup.__all__,
-    *ptaskgroup.__all__,
     *timer.__all__,
     '__version__',
 )
@@ -37,6 +35,5 @@ from .fork import *        # noqa
 from .func import *        # noqa
 from .iter import *        # noqa
 from .taskgroup import *   # noqa
-from .ptaskgroup import *   # noqa
 from .timer import *       # noqa
 from .server import *      # noqa

--- a/src/aiotools/ptaskgroup.py
+++ b/src/aiotools/ptaskgroup.py
@@ -8,6 +8,8 @@ from types import TracebackType
 from typing import (
     Any,
     Coroutine,
+    Generic,
+    List,
     Optional,
     Type,
     TypeVar,
@@ -25,7 +27,7 @@ __all__ = (
     'PersistentTaskGroup',
 )
 
-TAny = TypeVar('TAny')
+TResult = TypeVar('TResult')
 
 _ptaskgroup_idx = itertools.count()
 _log = logging.getLogger(__name__)
@@ -40,18 +42,32 @@ UNDEFINED = UndefinedResult.UNDEFINED
 
 
 class ExceptionHandler(Protocol):
-    async def __call__(self, exc: Exception) -> None:
+    async def __call__(self, exc: BaseException) -> None:
         ...
 
 
-async def _default_exc_handler(exc: Exception) -> None:
+async def _default_exc_handler(exc: BaseException) -> None:
     traceback.print_exc()
 
 
-class PersistentTaskGroup:
+class PersistentTaskGroup(Generic[TResult]):
+    """
+    Provides an abstraction of long-running task group for server applications.
 
+    If used as async context manager, it propagates cancellation from the parent task
+    into the child tasks.
+    It exits the context scope when all tasks finish, just like
+    :class:`asyncio.TaskGroup`.
+
+    If used without async context manager, it keeps running until
+    :method:`shutdown()` is called explicitly.
+    """
+
+    _base_error: Optional[BaseException]
     _exc_handler: ExceptionHandler
-    _tasks: "weakref.WeakSet[asyncio.Task[Any]]"
+    _errors: Optional[List[BaseException]]
+    _tasks: "weakref.WeakSet[asyncio.Task[TResult]]"
+    _on_completed_fut: Optional[asyncio.Future]
 
     def __init__(
         self,
@@ -59,7 +75,16 @@ class PersistentTaskGroup:
         name: str = None,
         exception_handler: ExceptionHandler = None,
     ) -> None:
+        self._entered = False
+        self._exiting = False
+        self._aborting = False
+        self._errors = []
+        self._base_error = None
         self._name = name or f"PTaskGroup-{next(_ptaskgroup_idx)}"
+        self._parent_cancel_requested = False
+        self._unfinished_tasks = 0
+        self._on_completed_fut = None
+        self._parent_task = compat.current_task()
         self._tasks = weakref.WeakSet()
         if exception_handler is None:
             self._exc_handler = _default_exc_handler
@@ -72,54 +97,109 @@ class PersistentTaskGroup:
 
     def create_task(
         self,
-        coro: Coroutine[Any, Any, TAny],
+        coro: Coroutine[Any, Any, TResult],
         *,
         name: str = None,
-    ) -> "asyncio.Task[Union[TAny, UndefinedResult]]":
-
-        # TODO: functools.wraps equivalent for coro?
-        async def wrapped_task() -> Union[TAny, UndefinedResult]:
-            current_task = compat.current_task()
-            assert current_task is not None
-            _log.debug("%r is spawned in %r.", current_task, self)
-            try:
-                return await coro
-            except asyncio.CancelledError:
-                _log.debug("%r in %r has been cancelled.", current_task, self)
-            except Exception as exc:
-                await self._exc_handler(exc)
-            except BaseException:
-                # TODO: implement
-                raise
-            # As our fallback handler handled the exception, the task should
-            # terminate silently with no explicit result.
-            # TODO: Add support for ExceptionGroup in Python 3.11, for the cases
-            #       with nested sub-tasks and sub-taskgroups.
-            return UNDEFINED
-
+    ) -> "asyncio.Task[TResult]":
         loop = compat.get_running_loop()
         if _has_task_name:
-            t = loop.create_task(wrapped_task(), name=name)
+            t = loop.create_task(coro, name=name)
         else:
-            t = loop.create_task(wrapped_task())
+            t = loop.create_task(coro)
+        _log.debug("%r is spawned in %r.", t, self)
+        self._unfinished_tasks += 1
+        t.add_done_callback(self._on_task_done)
         self._tasks.add(t)
         return t
 
-    async def shutdown(self) -> None:
-        remaining_tasks = {*self._tasks}
-        cancelled_tasks = set()
-        for t in remaining_tasks:
-            if t.cancelled():
-                continue
+    def _is_base_error(self, exc: BaseException) -> bool:
+        assert isinstance(exc, BaseException)
+        return isinstance(exc, (SystemExit, KeyboardInterrupt))
+
+    async def _wait_completion(self) -> Optional[BaseException]:
+        loop = compat.get_running_loop()
+        propagate_cancellation_error = None
+        while self._unfinished_tasks:
+            if self._on_completed_fut is None:
+                self._on_completed_fut = loop.create_future()
+            try:
+                await self._on_completed_fut
+            except asyncio.CancelledError as ex:
+                if not self._aborting:
+                    propagate_cancellation_error = ex
+                    self._trigger_shutdown()
+            self._on_completed_fut = None
+
+        assert self._unfinished_tasks == 0
+        self._on_completed_fut = None
+        return propagate_cancellation_error
+
+    def _trigger_shutdown(self) -> None:
+        self._aborting = True
+        for t in self._tasks:
             if not t.done():
                 t.cancel()
-                cancelled_tasks.add(t)
-        # Even though we handle CancelledError in wrapped_task,
-        # there are still possibilities to raise CancelledError
-        # when the tasks are not scheduled yet.
-        await asyncio.gather(*cancelled_tasks, return_exceptions=True)
+
+    async def shutdown(self) -> None:
+        self._trigger_shutdown()
+        await self._wait_completion()
+
+    def _on_exc_handler_done(self, task: asyncio.Task[None]) -> None:
+        self._unfinished_tasks -= 1
+        assert self._unfinished_tasks >= 0
+
+        # TODO: how to handle exceptions in the exception handler?
+        # TODO: prevent infinite recursion
+
+        if self._on_completed_fut is not None and not self._unfinished_tasks:
+            if not self._on_completed_fut.done():
+                self._on_completed_fut.set_result(True)
+
+    def _on_task_done(self, task: asyncio.Task[TResult]) -> None:
+        self._unfinished_tasks -= 1
+        assert self._unfinished_tasks >= 0
+        assert self._parent_task is not None
+        assert self._errors is not None
+        set_completed = False
+
+        if self._on_completed_fut is not None and not self._unfinished_tasks:
+            if not self._on_completed_fut.done():
+                set_completed = True
+
+        try:
+            if task.cancelled():
+                _log.debug("%r in %r has been cancelled.", task, self)
+                return
+
+            exc = task.exception()
+            if exc is None:
+                return
+
+            # Spawn our exception handler for non-base exceptions
+            # and swallow the error.
+            if not self._is_base_error(exc):
+                t = asyncio.create_task(self._exc_handler(exc))
+                t.add_done_callback(self._on_exc_handler_done)
+                self._tasks.add(t)
+                self._unfinished_tasks += 1
+                set_completed = False
+                return
+
+            # Now the exception is BaseException.
+            self._errors.append(exc)
+            if self._base_error is None:
+                self._base_error = exc
+
+            self._trigger_shutdown()
+            if not self._parent_task.cancelling():
+                self._parent_cancel_requested = True
+        finally:
+            if self._on_completed_fut is not None and set_completed:
+                self._on_completed_fut.set_result(True)
 
     async def __aenter__(self) -> "PersistentTaskGroup":
+        self._parent_task = compat.current_task()
+        self._entered = True
         return self
 
     async def __aexit__(
@@ -128,8 +208,60 @@ class PersistentTaskGroup:
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> Optional[bool]:
-        await self.shutdown()
-        return False
+        self._exiting = True
+        assert self._errors is not None
+        propagate_cancellation_error: Optional[
+            Union[Type[BaseException], BaseException]
+        ] = None
+
+        if (exc_val is not None and
+                self._is_base_error(exc_val) and
+                self._base_error is None):
+            self._base_error = exc_val
+
+        if exc_type is asyncio.CancelledError:
+            if self._parent_cancel_requested:
+                self._parent_task.uncancel()
+            else:
+                propagate_cancellation_error = exc_type
+        if exc_type is not None and not self._aborting:
+            if exc_type is asyncio.CancelledError:
+                propagate_cancellation_error = exc_type
+            self._trigger_shutdown()
+
+        prop_ex = await self._wait_completion()
+        if prop_ex is not None:
+            propagate_cancellation_error = prop_ex
+        if propagate_cancellation_error is not None:
+            raise propagate_cancellation_error
+
+        if exc_type is not None and exc_type is not asyncio.CancelledError:
+            # If there are any unhandled errors, let's add them to
+            # the bubbled up exception group.
+            # Normally, they should have been swallowed and logged
+            # by the fallback exception handler.
+            self._errors.append(exc_val)
+
+        if self._errors:
+            # Bubble up errors
+            errors = self._errors
+            self._errors = None
+            me = BaseExceptionGroup('unhandled errors in a TaskGroup', errors)
+            raise me from None
+
+        return None
 
     def __repr__(self) -> str:
-        return f"<PersistentTaskGroup {self.name}>"
+        info = ['']
+        if self._tasks:
+            info.append(f'tasks={len(self._tasks)}')
+        if self._unfinished_tasks:
+            info.append(f'unfinished={self._unfinished_tasks}')
+        if self._errors:
+            info.append(f'errors={len(self._errors)}')
+        if self._aborting:
+            info.append('cancelling')
+        elif self._entered:
+            info.append('entered')
+        info_str = ' '.join(info)
+        return f'<PersistentTaskGroup{info_str}>'

--- a/src/aiotools/ptaskgroup.py
+++ b/src/aiotools/ptaskgroup.py
@@ -64,23 +64,22 @@ class PersistentTaskGroup:
     When used as an async context manager, it works similarly to
     :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
     context scope when all tasks finish, just like :class:`asyncio.TaskGroup`, but
-    it does NOT abort when there are unhandled exceptions from child tasks, just
-    keep sibling tasks running, and report errors immediately (see below).
+    it does NOT abort when there are unhandled exceptions from child tasks; just
+    keeps sibling tasks running, and report errors immediately (see below).
 
     When *not* used as an async context maanger (e.g., used as attributes of
-    long-lived objects), it keeps running until :method:`shutdown()` is called
-    explicitly.  In this case, it persists until :method:`shutdown()` is explicitly
-    called.  Note that it is the user's responsibility to call :method:`shutdown()`
-    because ``PersistentTaskGroup`` does not provide the ``__del__()`` method.
+    long-lived objects), it persists running until :method:`shutdown()` is called
+    explicitly.  Note that it is the user's responsibility to call
+    :method:`shutdown()` because ``PersistentTaskGroup`` does not provide the
+    ``__del__()`` method.
 
-    Regardless how it is executed, it lets all spawned tasks to run to their
-    completion and then terminate and call the exception handler to report the
-    unhandled exceptions immediately.  If there are exceptions occurred again in the
-    exception handlers, then it uses
+    Regardless how it is executed, it lets all spawned tasks run to their completion
+    and calls the exception handler to report any unhandled exceptions immediately.
+    If there are exceptions occurred again in the exception handlers, then it uses
     :method:`AbstractEventLoop.call_exception_handler()` as the last resort.
 
-    In any case, the exception handling and reporting takes places immediately, to
-    eliminate potential arbitrary report delay due to other tasks or the execution
+    Since the exception handling and reporting takes places immediately, it
+    eliminates potential arbitrary report delay due to other tasks or the execution
     method.  This resolves a critical debugging pain when only termination of the
     application displays accumulated errors, as sometimes we don't want to terminate
     but just inspect what is happening.
@@ -97,7 +96,6 @@ class PersistentTaskGroup:
         *,
         name: str = None,
         exception_handler: ExceptionHandler = None,
-        # TODO: propagate_errors option?
     ) -> None:
         self._entered = False
         self._exiting = False
@@ -114,6 +112,8 @@ class PersistentTaskGroup:
             self._exc_handler = _default_exc_handler
         else:
             self._exc_handler = exception_handler
+
+    # TODO: task statistics and enumeration (for aiomonitor)
 
     @property
     def name(self) -> str:

--- a/src/aiotools/ptaskgroup.py
+++ b/src/aiotools/ptaskgroup.py
@@ -122,8 +122,7 @@ class PersistentTaskGroup:
     # TODO: task statistics and enumeration (for aiomonitor)
     # TODO: two-phase shutdown
 
-    @property
-    def name(self) -> str:
+    def get_name(self) -> str:
         return self._name
 
     def create_task(

--- a/src/aiotools/ptaskgroup.py
+++ b/src/aiotools/ptaskgroup.py
@@ -60,6 +60,12 @@ async def _default_exc_handler(exc_type, exc_obj, exc_tb) -> None:
 class PersistentTaskGroup:
     """
     Provides an abstraction of long-running task groups for server applications.
+    The main use case is to implement a dispatcher of async event handlers, to group
+    RPC/API request handlers, etc. with safe and graceful shutdown.
+    Here "long-running" means that all tasks should keep going even when sibling
+    tasks fail with unhandled errors and such errors must be reported immediately.
+    Here "safety" means that all spawned tasks should be reclaimed before exit or
+    shutdown.
 
     When used as an async context manager, it works similarly to
     :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
@@ -114,6 +120,7 @@ class PersistentTaskGroup:
             self._exc_handler = exception_handler
 
     # TODO: task statistics and enumeration (for aiomonitor)
+    # TODO: two-phase shutdown
 
     @property
     def name(self) -> str:

--- a/src/aiotools/ptaskgroup.py
+++ b/src/aiotools/ptaskgroup.py
@@ -59,13 +59,13 @@ async def _default_exc_handler(exc_type, exc_obj, exc_tb) -> None:
 
 class PersistentTaskGroup:
     """
-    Provides an abstraction of long-running task group for server applications.
+    Provides an abstraction of long-running task groups for server applications.
 
     When used as an async context manager, it works similarly to
     :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
     context scope when all tasks finish, just like :class:`asyncio.TaskGroup`, but
-    it does NOT abort when there are unhandled exceptions from child tasks and just
-    keep them running.
+    it does NOT abort when there are unhandled exceptions from child tasks, just
+    keep sibling tasks running, and report errors immediately (see below).
 
     When *not* used as an async context maanger (e.g., used as attributes of
     long-lived objects), it keeps running until :method:`shutdown()` is called
@@ -79,7 +79,7 @@ class PersistentTaskGroup:
     exception handlers, then it uses
     :method:`AbstractEventLoop.call_exception_handler()` as the last resort.
 
-    In any case, the exception handling and reporting happens immediately, to
+    In any case, the exception handling and reporting takes places immediately, to
     eliminate potential arbitrary report delay due to other tasks or the execution
     method.  This resolves a critical debugging pain when only termination of the
     application displays accumulated errors, as sometimes we don't want to terminate

--- a/src/aiotools/ptaskgroup.py
+++ b/src/aiotools/ptaskgroup.py
@@ -65,7 +65,7 @@ class PersistentTaskGroup:
     :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
     context scope when all tasks finish, just like :class:`asyncio.TaskGroup`, but
     it does NOT abort when there are unhandled exceptions from child tasks; just
-    keeps sibling tasks running, and report errors immediately (see below).
+    keeps sibling tasks running and reporting errors as they occur (see below).
 
     When *not* used as an async context maanger (e.g., used as attributes of
     long-lived objects), it persists running until :method:`shutdown()` is called

--- a/src/aiotools/ptaskgroup.py
+++ b/src/aiotools/ptaskgroup.py
@@ -101,6 +101,11 @@ class PersistentTaskGroup(Generic[TResult]):
         *,
         name: str = None,
     ) -> "asyncio.Task[TResult]":
+        if not self._entered:
+            # When used as object attribute, auto-enter.
+            self._entered = True
+        if self._exiting and self._unfinished_tasks == 0:
+            raise RuntimeError(f"{self!r} has already finished")
         loop = compat.get_running_loop()
         if _has_task_name:
             t = loop.create_task(coro, name=name)

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -1,8 +1,8 @@
-import sys
+import asyncio
 
 from .types import TaskGroupError
 
-if sys.version_info < (3, 11, 0, 'alpha', 6):
+if not hasattr(asyncio, 'TaskGroup'):
     from . import base_compat
     from . import persistent_compat
     from .base_compat import *        # noqa

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -1,0 +1,24 @@
+import sys
+
+from .types import TaskGroupError
+
+if sys.version_info < (3, 11):
+    from . import base_compat
+    from . import persistent_compat
+    from .base_compat import *        # noqa
+    from .persistent_compat import *  # noqa
+    __all__ = (
+        'TaskGroupError',
+        *base_compat.__all__,
+        *persistent_compat.__all__,
+    )
+else:
+    from . import base
+    from . import persistent
+    from .base import *        # noqa
+    from .persistent import *  # noqa
+    __all__ = (
+        'TaskGroupError',
+        *base.__all__,
+        *persistent.__all__,
+    )

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -2,7 +2,7 @@ import sys
 
 from .types import TaskGroupError
 
-if sys.version_info < (3, 11):
+if sys.version_info < (3, 11, 0, 'alpha', 6):
     from . import base_compat
     from . import persistent_compat
     from .base_compat import *        # noqa

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -2,17 +2,7 @@ import asyncio
 
 from .types import TaskGroupError
 
-if not hasattr(asyncio, 'TaskGroup'):
-    from . import base_compat
-    from . import persistent_compat
-    from .base_compat import *        # noqa
-    from .persistent_compat import *  # noqa
-    __all__ = (
-        'TaskGroupError',
-        *base_compat.__all__,
-        *persistent_compat.__all__,
-    )
-else:
+if hasattr(asyncio, 'TaskGroup'):
     from . import base
     from . import persistent
     from .base import *        # noqa
@@ -21,4 +11,14 @@ else:
         'TaskGroupError',
         *base.__all__,
         *persistent.__all__,
+    )
+else:
+    from . import base_compat
+    from . import persistent_compat
+    from .base_compat import *        # type: ignore  # noqa
+    from .persistent_compat import *  # type: ignore  # noqa
+    __all__ = (  # type: ignore
+        'TaskGroupError',
+        *base_compat.__all__,
+        *persistent_compat.__all__,
     )

--- a/src/aiotools/taskgroup/base.py
+++ b/src/aiotools/taskgroup/base.py
@@ -1,0 +1,36 @@
+import asyncio
+import sys
+from contextvars import ContextVar
+
+from .types import TaskGroupError
+
+
+assert sys.version_info >= (3, 11), "This module requires Python 3.11 or higher."
+
+
+__all__ = (
+    'TaskGroup',
+    'current_taskgroup',
+)
+
+current_taskgroup: ContextVar['TaskGroup'] = ContextVar('current_taskgroup')
+
+
+class TaskGroup(asyncio.TaskGroup):
+
+    async def __aenter__(self):
+        self._current_taskgroup_token = current_taskgroup.set(self)
+        return await super().__aenter__()
+
+    async def __aexit__(self, et, exc, tb):
+        try:
+            return await super().__aexit__(et, exc, tb)
+        except BaseExceptionGroup as eg:
+            # Just wrap the exception group as TaskGroupError for backward
+            # compatibility.  In Python 3.11 or higher, TaskGroupError
+            # also inherits BaseExceptionGroup, so the standard except*
+            # clauses and ExceptionGroup methods will work as expected.
+            # New codes should migrate to directly using asyncio.TaskGroup.
+            raise TaskGroupError(eg.message, eg.exceptions) from None
+        finally:
+            current_taskgroup.reset(self._current_taskgroup_token)

--- a/src/aiotools/taskgroup/base.py
+++ b/src/aiotools/taskgroup/base.py
@@ -4,9 +4,8 @@ from contextvars import ContextVar
 
 from .types import TaskGroupError
 
-
-assert sys.version_info >= (3, 11), "This module requires Python 3.11 or higher."
-
+assert sys.version_info >= (3, 11, 0, 'alpha', 6), \
+       "This module requires Python 3.11.0a6 or higher."
 
 __all__ = (
     'TaskGroup',

--- a/src/aiotools/taskgroup/base.py
+++ b/src/aiotools/taskgroup/base.py
@@ -1,11 +1,7 @@
 import asyncio
-import sys
 from contextvars import ContextVar
 
 from .types import TaskGroupError
-
-assert sys.version_info >= (3, 11, 0, 'alpha', 6), \
-       "This module requires Python 3.11.0a6 or higher."
 
 __all__ = (
     'TaskGroup',

--- a/src/aiotools/taskgroup/base_compat.py
+++ b/src/aiotools/taskgroup/base_compat.py
@@ -47,13 +47,6 @@ if has_contextvars:
 
 
 class TaskGroup:
-    """
-    Provides a guard against a group of tasks spawend via its :meth:`create_task`
-    method instead of the vanilla fire-and-forgetting :meth:`asyncio.create_task`.
-
-    See the motivation and rationale in `the trio's documentation
-    <https://trio.readthedocs.io/en/stable/reference-core.html#nurseries-and-spawning>`_.
-    """
 
     def __init__(self, *, name=None):
         if name is None:

--- a/src/aiotools/taskgroup/base_compat.py
+++ b/src/aiotools/taskgroup/base_compat.py
@@ -198,7 +198,7 @@ class TaskGroup:
     def create_task(self, coro, *, name=None):
         if not self._entered:
             raise RuntimeError(f"TaskGroup {self!r} has not been entered")
-        if self._exiting:
+        if self._exiting and self._unfinished_tasks == 0:
             raise RuntimeError(f"TaskGroup {self!r} is awaiting in exit")
         task = create_task_with_name(coro, name=name)
         task.add_done_callback(self._on_task_done)

--- a/src/aiotools/taskgroup/base_compat.py
+++ b/src/aiotools/taskgroup/base_compat.py
@@ -28,19 +28,16 @@ try:
     has_contextvars = True
 except ImportError:
     has_contextvars = False
-import functools
 import itertools
-import textwrap
-import traceback
 import weakref
 
-from .compat import current_task, get_running_loop
+from ..compat import current_task, get_running_loop
+from .common import patch_task
+from .types import TaskGroupError
 
 
 __all__ = [
-    'MultiError',
     'TaskGroup',
-    'TaskGroupError',
 ]
 
 
@@ -105,7 +102,7 @@ class TaskGroup:
         if self._parent_task is None:
             raise RuntimeError(
                 f'TaskGroup {self!r} cannot determine the parent task')
-        self._patch_task(self._parent_task)
+        patch_task(self._parent_task)
         if has_contextvars:
             self._current_taskgroup_token = current_taskgroup.set(self)
         return self
@@ -213,30 +210,6 @@ class TaskGroup:
         assert isinstance(exc, BaseException)
         return isinstance(exc, (SystemExit, KeyboardInterrupt))
 
-    def _patch_task(self, task):
-        # In Python 3.8 we'll need proper API on asyncio.Task to
-        # make TaskGroups possible. We need to be able to access
-        # information about task cancellation, more specifically,
-        # we need a flag to say if a task was cancelled or not.
-        # We also need to be able to flip that flag.
-
-        def _task_cancel(task, orig_cancel, msg=None):
-            task.__cancel_requested__ = True
-            if msg is not None:
-                return orig_cancel(msg)
-            else:
-                return orig_cancel()
-
-        if hasattr(task, '__cancel_requested__'):
-            return
-
-        task.__cancel_requested__ = False
-        # confirm that we were successful at adding the new attribute:
-        assert not task.__cancel_requested__
-
-        orig_cancel = task.cancel
-        task.cancel = functools.partial(_task_cancel, task, orig_cancel)
-
     def _abort(self):
         self._aborting = True
 
@@ -296,39 +269,6 @@ class TaskGroup:
             #                                 # after TaskGroup is finished.
             self._parent_cancel_requested = True
             self._parent_task.cancel()
-
-
-class MultiError(Exception):
-    """
-    Represents a collection of errors raised inside a task group.
-    Callers may iterate over the errors using the ``__erros__`` attribute.
-    """
-
-    def __init__(self, msg, *args, errors=()):
-        if errors:
-            types = set(type(e).__name__ for e in errors)
-            msg = f'{msg}; {len(errors)} sub errors: ({", ".join(types)})'
-            for er in errors:
-                msg += f'\n + {type(er).__name__}: {er}'
-                if er.__traceback__:
-                    er_tb = ''.join(traceback.format_tb(er.__traceback__))
-                    er_tb = textwrap.indent(er_tb, ' | ')
-                    msg += f'\n{er_tb}\n'
-        super().__init__(msg, *args)
-        self.__errors__ = tuple(errors)
-
-    def get_error_types(self):
-        return {type(e) for e in self.__errors__}
-
-    def __reduce__(self):
-        return (type(self), (self.args,), {'__errors__': self.__errors__})
-
-
-class TaskGroupError(MultiError):
-    """
-    An alias to :exc:`MultiError`.
-    """
-    pass
 
 
 _name_counter = itertools.count(1).__next__

--- a/src/aiotools/taskgroup/base_compat.py
+++ b/src/aiotools/taskgroup/base_compat.py
@@ -32,7 +32,7 @@ import itertools
 import weakref
 
 from ..compat import current_task, get_running_loop
-from .common import patch_task
+from .common import create_task_with_name, patch_task
 from .types import TaskGroupError
 
 
@@ -195,12 +195,12 @@ class TaskGroup:
                                 errors=errors)
             raise me from None
 
-    def create_task(self, coro):
+    def create_task(self, coro, *, name=None):
         if not self._entered:
             raise RuntimeError(f"TaskGroup {self!r} has not been entered")
         if self._exiting:
             raise RuntimeError(f"TaskGroup {self!r} is awaiting in exit")
-        task = self._loop.create_task(coro)
+        task = create_task_with_name(coro, name=name)
         task.add_done_callback(self._on_task_done)
         self._unfinished_tasks += 1
         self._tasks.add(task)

--- a/src/aiotools/taskgroup/common.py
+++ b/src/aiotools/taskgroup/common.py
@@ -1,0 +1,30 @@
+"""
+A set of common utilities for legacy Pythons
+"""
+
+import functools
+
+
+def patch_task(task) -> None:
+    # In Python 3.8 we'll need proper API on asyncio.Task to
+    # make TaskGroups possible. We need to be able to access
+    # information about task cancellation, more specifically,
+    # we need a flag to say if a task was cancelled or not.
+    # We also need to be able to flip that flag.
+
+    def _task_cancel(task, orig_cancel, msg=None):
+        task.__cancel_requested__ = True
+        if msg is not None:
+            return orig_cancel(msg)
+        else:
+            return orig_cancel()
+
+    if hasattr(task, '__cancel_requested__'):
+        return
+
+    task.__cancel_requested__ = False
+    # confirm that we were successful at adding the new attribute:
+    assert not task.__cancel_requested__
+
+    orig_cancel = task.cancel
+    task.cancel = functools.partial(_task_cancel, task, orig_cancel)

--- a/src/aiotools/taskgroup/common.py
+++ b/src/aiotools/taskgroup/common.py
@@ -2,7 +2,21 @@
 A set of common utilities for legacy Pythons
 """
 
+import asyncio
 import functools
+
+from .. import compat
+
+_has_task_name = hasattr(asyncio.Task, 'get_name')
+
+
+def create_task_with_name(coro, *, name=None):
+    loop = compat.get_running_loop()
+    if _has_task_name and name:
+        child_task = loop.create_task(coro, name=name)
+    else:
+        child_task = loop.create_task(coro)
+    return child_task
 
 
 def patch_task(task) -> None:

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -3,7 +3,7 @@ import itertools
 import logging
 import sys
 import traceback
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from types import TracebackType
 from typing import (
     Any,
@@ -41,6 +41,7 @@ class PersistentTaskGroup:
     _errors: Optional[List[BaseException]]
     _tasks: "weakref.WeakSet[asyncio.Task]"
     _on_completed_fut: Optional[asyncio.Future]
+    _current_taskgroup_token: Optional[Token["PersistentTaskGroup"]]
 
     def __init__(
         self,

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -1,0 +1,292 @@
+import asyncio
+import itertools
+import logging
+import sys
+import traceback
+from types import TracebackType
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    Optional,
+    Type,
+    Union,
+)
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore  # noqa
+import weakref
+
+from .. import compat
+from .types import AsyncExceptionHandler
+
+assert sys.version_info >= (3, 11), "This module requires Python 3.11 or higher."
+
+__all__ = (
+    'PersistentTaskGroup',
+)
+
+_ptaskgroup_idx = itertools.count()
+_log = logging.getLogger(__name__)
+
+
+async def _default_exc_handler(exc_type, exc_obj, exc_tb) -> None:
+    traceback.print_exc()
+
+
+class PersistentTaskGroup:
+    """
+    Provides an abstraction of long-running task groups for server applications.
+    The main use case is to implement a dispatcher of async event handlers, to group
+    RPC/API request handlers, etc. with safe and graceful shutdown.
+    Here "long-running" means that all tasks should keep going even when sibling
+    tasks fail with unhandled errors and such errors must be reported immediately.
+    Here "safety" means that all spawned tasks should be reclaimed before exit or
+    shutdown.
+
+    When used as an async context manager, it works similarly to
+    :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
+    context scope when all tasks finish, just like :class:`asyncio.TaskGroup`, but
+    it does NOT abort when there are unhandled exceptions from child tasks; just
+    keeps sibling tasks running and reporting errors as they occur (see below).
+
+    When *not* used as an async context maanger (e.g., used as attributes of
+    long-lived objects), it persists running until :method:`shutdown()` is called
+    explicitly.  Note that it is the user's responsibility to call
+    :method:`shutdown()` because ``PersistentTaskGroup`` does not provide the
+    ``__del__()`` method.
+
+    Regardless how it is executed, it lets all spawned tasks run to their completion
+    and calls the exception handler to report any unhandled exceptions immediately.
+    If there are exceptions occurred again in the exception handlers, then it uses
+    :method:`AbstractEventLoop.call_exception_handler()` as the last resort.
+
+    Since the exception handling and reporting takes places immediately, it
+    eliminates potential arbitrary report delay due to other tasks or the execution
+    method.  This resolves a critical debugging pain when only termination of the
+    application displays accumulated errors, as sometimes we don't want to terminate
+    but just inspect what is happening.
+    """
+
+    _base_error: Optional[BaseException]
+    _exc_handler: AsyncExceptionHandler
+    _errors: Optional[List[BaseException]]
+    _tasks: "weakref.WeakSet[asyncio.Task]"
+    _on_completed_fut: Optional[asyncio.Future]
+
+    def __init__(
+        self,
+        *,
+        name: str = None,
+        exception_handler: AsyncExceptionHandler = None,
+    ) -> None:
+        self._entered = False
+        self._exiting = False
+        self._aborting = False
+        self._errors = []
+        self._base_error = None
+        self._name = name or f"{next(_ptaskgroup_idx)}"
+        self._parent_cancel_requested = False
+        self._unfinished_tasks = 0
+        self._on_completed_fut = None
+        self._parent_task = compat.current_task()
+        self._tasks = weakref.WeakSet()
+        if exception_handler is None:
+            self._exc_handler = _default_exc_handler
+        else:
+            self._exc_handler = exception_handler
+
+    # TODO: task statistics and enumeration (for aiomonitor)
+    # TODO: two-phase shutdown
+
+    def get_name(self) -> str:
+        return self._name
+
+    def create_task(
+        self,
+        coro: Coroutine[Any, Any, Any],
+        *,
+        name: str = None,
+    ) -> "asyncio.Task":
+        if not self._entered:
+            # When used as object attribute, auto-enter.
+            self._entered = True
+        if self._exiting and self._unfinished_tasks == 0:
+            raise RuntimeError(f"{self!r} has already finished")
+        return self._create_task_with_name(coro, name=name, cb=self._on_task_done)
+
+    def _create_task_with_name(
+        self,
+        coro: Coroutine[Any, Any, Any],
+        *,
+        name: str = None,
+        cb: Callable[[asyncio.Task], Any],
+    ) -> "asyncio.Task":
+        loop = compat.get_running_loop()
+        child_task = loop.create_task(self._task_wrapper(coro), name=name)
+        _log.debug("%r is spawned in %r.", child_task, self)
+        self._unfinished_tasks += 1
+        child_task.add_done_callback(cb)
+        self._tasks.add(child_task)
+        return child_task
+
+    def _is_base_error(self, exc: BaseException) -> bool:
+        assert isinstance(exc, BaseException)
+        return isinstance(exc, (SystemExit, KeyboardInterrupt))
+
+    async def _wait_completion(self) -> Optional[BaseException]:
+        loop = compat.get_running_loop()
+        propagate_cancellation_error = None
+        while self._unfinished_tasks:
+            if self._on_completed_fut is None:
+                self._on_completed_fut = loop.create_future()
+            try:
+                await self._on_completed_fut
+            except asyncio.CancelledError as ex:
+                if not self._aborting:
+                    propagate_cancellation_error = ex
+                    self._trigger_shutdown()
+            self._on_completed_fut = None
+
+        assert self._unfinished_tasks == 0
+        self._on_completed_fut = None
+        return propagate_cancellation_error
+
+    def _trigger_shutdown(self) -> None:
+        self._aborting = True
+        for t in self._tasks:
+            if not t.done():
+                t.cancel()
+
+    async def shutdown(self) -> None:
+        self._trigger_shutdown()
+        await self._wait_completion()
+
+    async def _task_wrapper(self, coro: Coroutine) -> Any:
+        loop = compat.get_running_loop()
+        task = compat.current_task()
+        try:
+            return await coro
+        except Exception:
+            # Swallow unhandled exceptions by our own and
+            # prevent abortion of the task group bu them.
+            # Wrapping corotuines directly has advantage for
+            # exception handlers to access full traceback
+            # and there is no need to implement separate
+            # mechanism to wait for exception handler tasks.
+            try:
+                await self._exc_handler(*sys.exc_info())
+            except Exception as exc:
+                # If there are exceptions inside the exception handler
+                # we report it as soon as possible using the event loop's
+                # exception handler, instead of postponing
+                # to the timing when PersistentTaskGroup terminates.
+                loop.call_exception_handler({
+                    'message': f"Got an unhandled exception "
+                               f"in the exception handler of Task {task!r}",
+                    'exception': exc,
+                    'task': task,
+                })
+
+    def _on_task_done(self, task: asyncio.Task) -> None:
+        self._unfinished_tasks -= 1
+        assert self._unfinished_tasks >= 0
+        assert self._parent_task is not None
+        assert self._errors is not None
+
+        if self._on_completed_fut is not None and not self._unfinished_tasks:
+            if not self._on_completed_fut.done():
+                self._on_completed_fut.set_result(True)
+
+        if task.cancelled():
+            _log.debug("%r in %r has been cancelled.", task, self)
+            return
+
+        exc = task.exception()
+        if exc is None:
+            return
+
+        # Now the exception is BaseException.
+        self._errors.append(exc)
+        if self._base_error is None:
+            self._base_error = exc
+
+        self._trigger_shutdown()
+        if not self._parent_task.cancelling():
+            self._parent_cancel_requested = True
+
+    async def __aenter__(self) -> "PersistentTaskGroup":
+        self._parent_task = compat.current_task()
+        self._entered = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self._exiting = True
+        assert self._errors is not None
+        propagate_cancellation_error: Optional[
+            Union[Type[BaseException], BaseException]
+        ] = None
+
+        if (exc_val is not None and
+                self._is_base_error(exc_val) and
+                self._base_error is None):
+            self._base_error = exc_val
+
+        if exc_type is asyncio.CancelledError:
+            if self._parent_cancel_requested:
+                self._parent_task.uncancel()
+            else:
+                propagate_cancellation_error = exc_type
+        if exc_type is not None and not self._aborting:
+            if exc_type is asyncio.CancelledError:
+                propagate_cancellation_error = exc_type
+            self._trigger_shutdown()
+
+        prop_ex = await self._wait_completion()
+        if prop_ex is not None:
+            propagate_cancellation_error = prop_ex
+        if propagate_cancellation_error is not None:
+            raise propagate_cancellation_error
+
+        if exc_val is not None and exc_type is not asyncio.CancelledError:
+            # If there are any unhandled errors, let's add them to
+            # the bubbled up exception group.
+            # Normally, they should have been swallowed and logged
+            # by the fallback exception handler.
+            self._errors.append(exc_val)
+
+        if self._errors:
+            # Bubble up errors
+            errors = self._errors
+            self._errors = None
+            me = BaseExceptionGroup(
+                'unhandled errors in a PersistentTaskGroup',
+                errors,
+            )
+            raise me from None
+
+        return None
+
+    def __repr__(self) -> str:
+        info = ['']
+        if self._name:
+            info.append(f'name={self._name}')
+        if self._tasks:
+            info.append(f'tasks={len(self._tasks)}')
+        if self._unfinished_tasks:
+            info.append(f'unfinished={self._unfinished_tasks}')
+        if self._errors:
+            info.append(f'errors={len(self._errors)}')
+        if self._aborting:
+            info.append('cancelling')
+        elif self._entered:
+            info.append('entered')
+        info_str = ' '.join(info)
+        return f'<PersistentTaskGroup({info_str})>'

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -18,7 +18,8 @@ import weakref
 from .. import compat
 from .types import AsyncExceptionHandler
 
-assert sys.version_info >= (3, 11), "This module requires Python 3.11 or higher."
+assert sys.version_info >= (3, 11, 0, 'alpha', 6), \
+       "This module requires Python 3.11.0a6 or higher."
 
 __all__ = (
     'PersistentTaskGroup',

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -18,9 +18,6 @@ import weakref
 from .. import compat
 from .types import AsyncExceptionHandler
 
-assert sys.version_info >= (3, 11, 0, 'alpha', 6), \
-       "This module requires Python 3.11.0a6 or higher."
-
 __all__ = (
     'PersistentTaskGroup',
 )

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -13,10 +13,6 @@ from typing import (
     Type,
     Union,
 )
-try:
-    from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore  # noqa
 import weakref
 
 from .. import compat

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -31,38 +31,6 @@ async def _default_exc_handler(exc_type, exc_obj, exc_tb) -> None:
 
 
 class PersistentTaskGroup:
-    """
-    Provides an abstraction of long-running task groups for server applications.
-    The main use case is to implement a dispatcher of async event handlers, to group
-    RPC/API request handlers, etc. with safe and graceful shutdown.
-    Here "long-running" means that all tasks should keep going even when sibling
-    tasks fail with unhandled errors and such errors must be reported immediately.
-    Here "safety" means that all spawned tasks should be reclaimed before exit or
-    shutdown.
-
-    When used as an async context manager, it works similarly to
-    :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
-    context scope when all tasks finish, just like :class:`asyncio.TaskGroup`, but
-    it does NOT abort when there are unhandled exceptions from child tasks; just
-    keeps sibling tasks running and reporting errors as they occur (see below).
-
-    When *not* used as an async context maanger (e.g., used as attributes of
-    long-lived objects), it persists running until :method:`shutdown()` is called
-    explicitly.  Note that it is the user's responsibility to call
-    :method:`shutdown()` because ``PersistentTaskGroup`` does not provide the
-    ``__del__()`` method.
-
-    Regardless how it is executed, it lets all spawned tasks run to their completion
-    and calls the exception handler to report any unhandled exceptions immediately.
-    If there are exceptions occurred again in the exception handlers, then it uses
-    :method:`AbstractEventLoop.call_exception_handler()` as the last resort.
-
-    Since the exception handling and reporting takes places immediately, it
-    eliminates potential arbitrary report delay due to other tasks or the execution
-    method.  This resolves a critical debugging pain when only termination of the
-    application displays accumulated errors, as sometimes we don't want to terminate
-    but just inspect what is happening.
-    """
 
     _base_error: Optional[BaseException]
     _exc_handler: AsyncExceptionHandler

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -15,7 +15,7 @@ from typing import (
 import weakref
 
 from .. import compat
-from .common import patch_task
+from .common import create_task_with_name, patch_task
 from .types import AsyncExceptionHandler, TaskGroupError
 
 __all__ = (
@@ -24,7 +24,6 @@ __all__ = (
 
 _ptaskgroup_idx = itertools.count()
 _log = logging.getLogger(__name__)
-_has_task_name = (sys.version_info >= (3, 8, 0))
 
 
 async def _default_exc_handler(exc_type, exc_obj, exc_tb) -> None:
@@ -119,11 +118,7 @@ class PersistentTaskGroup:
         name: str = None,
         cb: Callable[[asyncio.Task], Any],
     ) -> "asyncio.Task":
-        loop = compat.get_running_loop()
-        if _has_task_name and name:
-            child_task = loop.create_task(self._task_wrapper(coro), name=name)
-        else:
-            child_task = loop.create_task(self._task_wrapper(coro))
+        child_task = create_task_with_name(self._task_wrapper(coro), name=name)
         _log.debug("%r is spawned in %r.", child_task, self)
         self._unfinished_tasks += 1
         child_task.add_done_callback(cb)

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -31,38 +31,6 @@ async def _default_exc_handler(exc_type, exc_obj, exc_tb) -> None:
 
 
 class PersistentTaskGroup:
-    """
-    Provides an abstraction of long-running task groups for server applications.
-    The main use case is to implement a dispatcher of async event handlers, to group
-    RPC/API request handlers, etc. with safe and graceful shutdown.
-    Here "long-running" means that all tasks should keep going even when sibling
-    tasks fail with unhandled errors and such errors must be reported immediately.
-    Here "safety" means that all spawned tasks should be reclaimed before exit or
-    shutdown.
-
-    When used as an async context manager, it works similarly to
-    :func:`asyncio.gather()` with ``return_exceptions=True`` option.  It exits the
-    context scope when all tasks finish, just like :class:`asyncio.TaskGroup`, but
-    it does NOT abort when there are unhandled exceptions from child tasks; just
-    keeps sibling tasks running and reporting errors as they occur (see below).
-
-    When *not* used as an async context maanger (e.g., used as attributes of
-    long-lived objects), it persists running until :method:`shutdown()` is called
-    explicitly.  Note that it is the user's responsibility to call
-    :method:`shutdown()` because ``PersistentTaskGroup`` does not provide the
-    ``__del__()`` method.
-
-    Regardless how it is executed, it lets all spawned tasks run to their completion
-    and calls the exception handler to report any unhandled exceptions immediately.
-    If there are exceptions occurred again in the exception handlers, then it uses
-    :method:`AbstractEventLoop.call_exception_handler()` as the last resort.
-
-    Since the exception handling and reporting takes places immediately, it
-    eliminates potential arbitrary report delay due to other tasks or the execution
-    method.  This resolves a critical debugging pain when only termination of the
-    application displays accumulated errors, as sometimes we don't want to terminate
-    but just inspect what is happening.
-    """
 
     _base_error: Optional[BaseException]
     _exc_handler: AsyncExceptionHandler

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -12,10 +12,6 @@ from typing import (
     Optional,
     Type,
 )
-try:
-    from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore  # noqa
 import weakref
 
 from .. import compat

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import traceback
 try:
-    from contextvars import ContextVar
+    from contextvars import ContextVar, Token
     has_contextvars = True
 except ImportError:
     has_contextvars = False
@@ -47,6 +47,7 @@ class PersistentTaskGroup:
     _errors: Optional[List[BaseException]]
     _tasks: "weakref.WeakSet[asyncio.Task]"
     _on_completed_fut: Optional[asyncio.Future]
+    _current_taskgroup_token: Optional["Token[PersistentTaskGroup]"]
 
     def __init__(
         self,

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -1,7 +1,11 @@
 import sys
 import textwrap
 import traceback
-from typing import Protocol, Type
+from typing import Type
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore  # noqa
 from types import TracebackType
 
 

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -1,4 +1,4 @@
-import sys
+import asyncio
 import textwrap
 import traceback
 from typing import Type
@@ -24,7 +24,7 @@ class AsyncExceptionHandler(Protocol):
         ...
 
 
-if sys.version_info < (3, 11, 0, 'alpha', 6):
+if not hasattr(asyncio, 'BaseExceptionGroup'):
 
     class MultiError(Exception):
         """

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -24,7 +24,7 @@ class AsyncExceptionHandler(Protocol):
         ...
 
 
-if sys.version_info < (3, 11):
+if sys.version_info < (3, 11, 0, 'alpha', 6):
 
     class MultiError(Exception):
         """

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -1,0 +1,71 @@
+import sys
+import textwrap
+import traceback
+from typing import Protocol, Type
+from types import TracebackType
+
+
+class AsyncExceptionHandler(Protocol):
+    """
+    A shorthand for an async exception handler type.
+    This is always called under exception context where
+    :func:`sys.exc_info()` is available.
+    """
+    async def __call__(
+        self,
+        exc_type: Type[Exception],
+        exc_obj: Exception,
+        exc_tb: TracebackType,
+    ) -> None:
+        ...
+
+
+if sys.version_info < (3, 11):
+
+    class MultiError(Exception):
+        """
+        Represents a collection of errors raised inside a task group.
+        Callers may iterate over the errors using the ``__errors__`` attribute.
+        """
+
+        def __init__(self, msg, errors=()):
+            if errors:
+                types = set(type(e).__name__ for e in errors)
+                msg = f'{msg}; {len(errors)} sub errors: ({", ".join(types)})'
+                for er in errors:
+                    msg += f'\n + {type(er).__name__}: {er}'
+                    if er.__traceback__:
+                        er_tb = ''.join(traceback.format_tb(er.__traceback__))
+                        er_tb = textwrap.indent(er_tb, ' | ')
+                        msg += f'\n{er_tb}\n'
+            super().__init__(msg)
+            self.__errors__ = tuple(errors)
+
+        def get_error_types(self):
+            return {type(e) for e in self.__errors__}
+
+        def __reduce__(self):
+            return (type(self), (self.args,), {'__errors__': self.__errors__})
+
+    class TaskGroupError(MultiError):
+        """
+        An alias to :exc:`MultiError`.
+        """
+        pass
+
+else:
+
+    class MultiError(BaseExceptionGroup):
+        """
+        An adapter for the ExceptionGroup to keep backward compatibility.
+        """
+
+        def __init__(self, msg, errors=()):
+            super().__init__(msg, errors)
+            self.__errors__ = errors
+
+        def get_error_types(self):
+            return {type(e) for e in self.exceptions}
+
+    class TaskGroupError(MultiError):
+        pass

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -27,10 +27,6 @@ class AsyncExceptionHandler(Protocol):
 if not hasattr(asyncio, 'BaseExceptionGroup'):
 
     class MultiError(Exception):
-        """
-        Represents a collection of errors raised inside a task group.
-        Callers may iterate over the errors using the ``__errors__`` attribute.
-        """
 
         def __init__(self, msg, errors=()):
             if errors:
@@ -60,9 +56,6 @@ if not hasattr(asyncio, 'BaseExceptionGroup'):
 else:
 
     class MultiError(BaseExceptionGroup):
-        """
-        An adapter for the ExceptionGroup to keep backward compatibility.
-        """
 
         def __init__(self, msg, errors=()):
             super().__init__(msg, errors)

--- a/src/aiotools/timer.py
+++ b/src/aiotools/timer.py
@@ -86,7 +86,8 @@ class VirtualClock:
         return self.vtime
 
     def _virtual_select(self, orig_select, timeout):
-        self.vtime += timeout
+        if timeout is not None:
+            self.vtime += timeout
         return orig_select(0)  # override the timeout to zero
 
     @contextlib.contextmanager

--- a/tests/test_ptaskgroup.py
+++ b/tests/test_ptaskgroup.py
@@ -249,6 +249,10 @@ async def test_ptaskgroup_exc_handler_swallow():
         assert tg._unfinished_tasks == 0
 
 
+@pytest.mark.skipif(
+    sys.version_info <= (3, 8, 0),
+    reason='Requires Python 3.8 or higher',
+)
 @pytest.mark.asyncio
 async def test_ptaskgroup_error_in_exc_handlers():
 

--- a/tests/test_ptaskgroup.py
+++ b/tests/test_ptaskgroup.py
@@ -1,9 +1,10 @@
-import aiotools
 import asyncio
 import sys
 from unittest import mock
 
 import pytest
+
+import aiotools
 
 
 # NOTE: Until pytest-asyncio support ExceptionGroup,
@@ -150,7 +151,7 @@ async def test_ptaskgroup_shutdown_from_different_task():
             await asyncio.sleep(0.49)
             await tg.shutdown()
 
-        async with asyncio.TaskGroup() as outer_tg:
+        async with aiotools.TaskGroup() as outer_tg:
             outer_tg.create_task(_main_task())
             outer_tg.create_task(_stop_task())
 

--- a/tests/test_ptaskgroup.py
+++ b/tests/test_ptaskgroup.py
@@ -269,14 +269,12 @@ async def test_ptaskgroup_error_in_exc_handlers():
 
     loop = aiotools.compat.get_running_loop()
     vclock = aiotools.VirtualClock()
-    with (
-        vclock.patch_loop(),
-        mock.patch.object(
-            loop,
-            'call_exception_handler',
-            mock.MagicMock(),
-        ),
-    ):
+    with vclock.patch_loop(), \
+         mock.patch.object(
+             loop,
+             'call_exception_handler',
+             mock.MagicMock(),
+         ):
         # Errors in exception handlers are covered by the event loop's exception
         # handler, so that they can be reported as soon as possible when they occur.
         #

--- a/tests/test_ptaskgroup.py
+++ b/tests/test_ptaskgroup.py
@@ -127,13 +127,13 @@ async def test_ptaskgroup_shutdown_from_different_task():
     vclock = aiotools.VirtualClock()
     with vclock.patch_loop():
 
-        outer_myself = asyncio.current_task()
+        outer_myself = aiotools.compat.current_task()
         tg = aiotools.PersistentTaskGroup()
         assert tg._parent_task is outer_myself
 
         async def _main_task():
             nonlocal exec_after_termination
-            myself = asyncio.current_task()
+            myself = aiotools.compat.current_task()
             async with tg:
                 # The parent task is overriden when
                 # using "async with", to keep consistency with

--- a/tests/test_ptaskgroup.py
+++ b/tests/test_ptaskgroup.py
@@ -24,7 +24,7 @@ async def test_ptaskgroup_naming():
 
     async with aiotools.PersistentTaskGroup(name="XYZ") as tg:
         t = tg.create_task(subtask(), name="ABC")
-        assert tg.name == "XYZ"
+        assert tg.get_name() == "XYZ"
         assert t.get_name() == "ABC"
 
 

--- a/tests/test_ptaskgroup.py
+++ b/tests/test_ptaskgroup.py
@@ -237,10 +237,10 @@ async def test_ptaskgroup_exc_handler_swallow():
                 for _ in range(10):
                     tg.create_task(subtask())
                 assert len(tg._tasks) == 10
-        except* ZeroDivisionError:
+        except ExceptionGroup as eg:
             # All non-base exceptions must be swallowed by
             # our exception handler.
-            assert False, "should not reach here"
+            assert len(eg.subgroup(ZeroDivisionError).exceptions) == 0
 
         assert done_count == 0
         assert error_count == 10
@@ -312,7 +312,7 @@ async def test_ptaskgroup_error_in_exc_handlers():
             async with aiotools.PersistentTaskGroup(exception_handler=handler) as tg:
                 for _ in range(10):
                     tg.create_task(subtask())
-        except* Exception:
+        except ExceptionGroup:
             assert False, "should not reach here"
 
         # Check if the event loop exception handler is called.

--- a/tests/test_ptaskgroup.py
+++ b/tests/test_ptaskgroup.py
@@ -10,13 +10,13 @@ async def test_ptaskgroup_all_done():
 
     count = 0
 
+    async def subtask():
+        nonlocal count
+        await asyncio.sleep(0.1)
+        count += 1
+
     vclock = aiotools.VirtualClock()
     with vclock.patch_loop():
-
-        async def subtask():
-            nonlocal count
-            await asyncio.sleep(0.1)
-            count += 1
 
         async with aiotools.PersistentTaskGroup() as tg:
             assert tg.name.startswith("PTaskGroup-")
@@ -24,7 +24,7 @@ async def test_ptaskgroup_all_done():
                 t = tg.create_task(subtask(), name=f"Task-{idx}")
                 if sys.version_info >= (3, 8):
                     assert t.get_name() == f"Task-{idx}"
-                del t  # to prevent ref-leak after loop
+                del t  # prevent ref-leak after loop
             assert len(tg._tasks) == 10
             # all done
             await asyncio.sleep(0.2)
@@ -32,6 +32,88 @@ async def test_ptaskgroup_all_done():
             assert len(tg._tasks) == 0
 
         assert count == 10
+
+
+@pytest.mark.asyncio
+async def test_ptaskgroup_as_obj_attr():
+
+    count = 0
+
+    async def subtask():
+        nonlocal count
+        await asyncio.sleep(0.1)
+        count += 1
+
+    class LongLivedObject:
+
+        def __init__(self):
+            self.tg = aiotools.PersistentTaskGroup()
+
+        async def work(self):
+            self.tg.create_task(subtask())
+
+        async def aclose(self):
+            await self.tg.shutdown()
+
+    vclock = aiotools.VirtualClock()
+    with vclock.patch_loop():
+
+        obj = LongLivedObject()
+        for idx in range(10):
+            await obj.work()
+        assert len(obj.tg._tasks) == 10
+
+        # shutdown after all done
+        await asyncio.sleep(0.2)
+        await obj.aclose()
+
+        assert count == 10
+        assert len(obj.tg._tasks) == 0
+
+        count = 0
+        obj = LongLivedObject()
+        for idx in range(10):
+            await obj.work()
+        assert len(obj.tg._tasks) == 10
+
+        # shutdown immediately
+        await obj.aclose()
+
+        assert count == 0
+        assert len(obj.tg._tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_ptaskgroup_shutdown_from_different_task():
+
+    count = 0
+
+    async def subtask(idx):
+        nonlocal count
+        await asyncio.sleep(0.1 * idx)
+        count += 1
+
+    vclock = aiotools.VirtualClock()
+    with vclock.patch_loop():
+
+        tg = aiotools.PersistentTaskGroup()
+
+        async def _main_task():
+            async with tg:
+                for idx in range(10):
+                    tg.create_task(subtask(idx))
+                assert len(tg._tasks) == 10
+
+        async def _canceller_task():
+            await asyncio.sleep(0.49)
+            await tg.shutdown()
+
+        async with asyncio.TaskGroup() as outer_tg:
+            outer_tg.create_task(_main_task())
+            outer_tg.create_task(_canceller_task())
+
+        assert count == 5
+        assert len(tg._tasks) == 0
 
 
 @pytest.mark.asyncio
@@ -52,12 +134,11 @@ async def test_ptaskgroup_cancel_after_schedule():
                 tg.create_task(subtask())
             await asyncio.sleep(0)
             assert len(tg._tasks) == 10
-            # all cancelled after scheduled
 
-        assert count == 0
-        assert len(tg._tasks) == 10
-        await asyncio.sleep(0)
-        # after cancellation, all refs should be gone
+        # shutdown after exit (all done) is no-op.
+        assert count == 10
+        assert len(tg._tasks) == 0
+        await tg.shutdown()
         assert len(tg._tasks) == 0
 
 
@@ -78,12 +159,10 @@ async def test_ptaskgroup_cancel_before_schedule():
             for _ in range(10):
                 tg.create_task(subtask())
             assert len(tg._tasks) == 10
-            # all cancelled before scheduled
+            # let's abort immediately.
+            await tg.shutdown()
 
         assert count == 0
-        assert len(tg._tasks) == 10
-        await asyncio.sleep(0)
-        # after cancellation, all refs should be gone
         assert len(tg._tasks) == 0
 
 
@@ -93,19 +172,19 @@ async def test_ptaskgroup_exc_handler():
     count = 0
     error_count = 0
 
+    async def subtask():
+        nonlocal count
+        await asyncio.sleep(0.1)
+        1 / 0
+        count += 1
+
+    async def handler(e):
+        nonlocal error_count
+        assert isinstance(e, ZeroDivisionError)
+        error_count += 1
+
     vclock = aiotools.VirtualClock()
     with vclock.patch_loop():
-
-        async def subtask():
-            nonlocal count
-            await asyncio.sleep(0.1)
-            1 / 0
-            count += 1
-
-        async def handler(e):
-            nonlocal error_count
-            assert isinstance(e, ZeroDivisionError)
-            error_count += 1
 
         async with aiotools.PersistentTaskGroup(exception_handler=handler) as tg:
             for _ in range(10):
@@ -115,7 +194,6 @@ async def test_ptaskgroup_exc_handler():
 
         assert count == 0
         assert error_count == 10
-        # after handling error, all refs should be gone
         assert len(tg._tasks) == 0
 
 
@@ -124,27 +202,26 @@ async def test_ptaskgroup_cancel_with_await():
 
     count = 0
 
+    async def subtask():
+        nonlocal count
+        try:
+            await asyncio.sleep(0.1)
+            count += 1   # should not be executed
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.1)
+            count += 10  # should be executed
+
     vclock = aiotools.VirtualClock()
     with vclock.patch_loop():
-
-        async def subtask():
-            nonlocal count
-            try:
-                await asyncio.sleep(0.1)
-                count += 1   # should not be executed
-            except asyncio.CancelledError:
-                await asyncio.sleep(0.1)
-                count += 10  # should be executed
 
         async with aiotools.PersistentTaskGroup() as tg:
             for _ in range(10):
                 tg.create_task(subtask())
             assert len(tg._tasks) == 10
-            # close it immediately after starting subtasks
-            await asyncio.sleep(0)
+            # shutdown just after starting child tasks
+            await asyncio.sleep(0.01)
+            await tg.shutdown()
 
         # ensure that awaits in all cancellation handling blocks have been executed
         assert count == 100
-        # after handling error, all refs should be gone
-        await asyncio.sleep(0)
         assert len(tg._tasks) == 0

--- a/tests/test_taskgroup.py
+++ b/tests/test_taskgroup.py
@@ -87,14 +87,11 @@ async def test_contextual_taskgroup_spawning():
     with VirtualClock().patch_loop():
 
         total_jobs = 0
-        with pytest.raises(TaskGroupError), pytest.warns(RuntimeWarning):
-            # When the taskgroup terminates immediately after spawning subtasks,
-            # the spawned subtasks may not be allowed to proceed because the parent
-            # taskgroup is already in the terminating procedure.
-            async with TaskGroup() as tg:
-                t = tg.create_task(spawn_job())
-            assert not t.done()
-        assert total_jobs == 0
+        async with TaskGroup() as tg:
+            t = tg.create_task(spawn_job())
+        assert t.done()
+        del t
+        assert total_jobs == 1
 
         total_jobs = 0
         async with TaskGroup() as tg:


### PR DESCRIPTION
This PR rewrites `PersistenTaskGroup` for Python 3.11.
~~It works only for the latest Python 3.11 development version checked out from GitHub.~~
It supports `TaskGroup` and `PersistentTaskGroup` on Python 3.6 to 3.11, while `aiotools.TaskGroup` uses the stdlib's implementation on 3.11.0-alpha6 or later.  The test suite ensures the same behavior of the custom implementation and the stdlib.  At the time of writing, Python 3.11.0-alpha5 is the latest available build in GitHub Actions, so the CI runs only the custom implementations but I have checked the same test results on a local build of CPython.

refs https://bugs.python.org/issue46843