### PR TITLE
fix: Set `current_ptaskgroup` only in async-with blocks

### DIFF
--- a/changes/41.fix.md
+++ b/changes/41.fix.md
@@ -1,0 +1,1 @@
+Set `current_ptaskgroup` only when `PersistentTaskGroup` is used via the `async with` statement.

--- a/docs/aiotools.taskgroup.rst
+++ b/docs/aiotools.taskgroup.rst
@@ -16,6 +16,11 @@ Task Group
    A :class:`contextvars.ContextVar` that has the reference to the current innermost
    :class:`PersistentTaskGroup` instance.  Available only in Python 3.7 or later.
 
+   .. warning::
+
+      This is set only when :class:`PersistentTaskGroup` is used with the ``async
+      with`` statement.
+
 .. class:: TaskGroup(*, name=None)
 
    Provides a guard against a group of tasks spawend via its :meth:`create_task()`

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -93,8 +93,6 @@ class PersistentTaskGroup:
     ) -> "asyncio.Task":
         if not self._entered:
             # When used as object attribute, auto-enter.
-            if has_contextvars:
-                self._current_taskgroup_token = current_ptaskgroup.set(self)
             self._entered = True
         if self._exiting and self._unfinished_tasks == 0:
             raise RuntimeError(f"{self!r} has already finished")
@@ -133,10 +131,6 @@ class PersistentTaskGroup:
             self._on_completed_fut = None
 
         assert self._unfinished_tasks == 0
-        if has_contextvars:
-            if self._current_taskgroup_token:
-                current_ptaskgroup.reset(self._current_taskgroup_token)
-            self._current_taskgroup_token = None
         self._on_completed_fut = None
         _all_ptaskgroups.discard(self)
         return propagate_cancellation_error
@@ -243,6 +237,10 @@ class PersistentTaskGroup:
         prop_ex = await self._wait_completion()
         if prop_ex is not None:
             propagate_cancelation = prop_ex
+        if has_contextvars:
+            if self._current_taskgroup_token:
+                current_ptaskgroup.reset(self._current_taskgroup_token)
+            self._current_taskgroup_token = None
 
         if propagate_cancelation:
             # The wrapping task was cancelled; since we're done with

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -240,7 +240,7 @@ class PersistentTaskGroup:
         if has_contextvars:
             if self._current_taskgroup_token:
                 current_ptaskgroup.reset(self._current_taskgroup_token)
-            self._current_taskgroup_token = None
+                self._current_taskgroup_token = None
 
         if propagate_cancelation:
             # The wrapping task was cancelled; since we're done with


### PR DESCRIPTION
- fix: Set current_ptaskgroup only in async-with blocks
- docs: Add a warning about the new behavior
