### PR TITLE
fix: Feature detection for ExceptionGroup

### DIFF
--- a/changes/42.fix.md
+++ b/changes/42.fix.md
@@ -1,0 +1,1 @@
+Fix feature detection for `ExceptionGroup` and let `MultiError` inherit `ExceptionGroup` instead of `BaseExceptionGroup`

--- a/src/aiotools/taskgroup/base_compat.py
+++ b/src/aiotools/taskgroup/base_compat.py
@@ -185,7 +185,7 @@ class TaskGroup:
             self._errors = None
 
             me = TaskGroupError('unhandled errors in a TaskGroup',
-                                errors=errors)
+                                errors)
             raise me from None
 
     def create_task(self, coro, *, name=None):

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -1,4 +1,4 @@
-import asyncio
+import builtins
 import textwrap
 import traceback
 from typing import Type
@@ -24,7 +24,7 @@ class AsyncExceptionHandler(Protocol):
         ...
 
 
-if not hasattr(asyncio, 'BaseExceptionGroup'):
+if not hasattr(builtins, 'ExceptionGroup'):
 
     class MultiError(Exception):
 
@@ -55,7 +55,7 @@ if not hasattr(asyncio, 'BaseExceptionGroup'):
 
 else:
 
-    class MultiError(BaseExceptionGroup):
+    class MultiError(ExceptionGroup):
 
         def __init__(self, msg, errors=()):
             super().__init__(msg, errors)


### PR DESCRIPTION
* Let MultiError inherit ExceptionGroup instead of BaseExceptionGroup,
  to be consistent with legacy MultiError.
