### PR TITLE
server: Add wait_timeout and properly close pipe fds during afork

### DIFF
--- a/changes/46.fix.md
+++ b/changes/46.fix.md
@@ -1,0 +1,1 @@
+Resolve singal races by minimizing expose of event loop in `afork()`-ed child processes

--- a/src/aiotools/fork.py
+++ b/src/aiotools/fork.py
@@ -205,6 +205,7 @@ async def _fork_posix(child_func: Callable[[], int]) -> int:
 
     pid = os.fork()
     if pid == 0:
+        os.close(init_pipe[0])
         ret = 0
         try:
             ret = _child_main(None, init_pipe[1], child_func)
@@ -212,6 +213,8 @@ async def _fork_posix(child_func: Callable[[], int]) -> int:
             ret = -signal.SIGINT
         finally:
             os._exit(ret)
+        return ret
+    os.close(init_pipe[1])
 
     # Wait for the child's readiness notification
     init_event = asyncio.Event()
@@ -229,6 +232,7 @@ async def _clone_pidfd(child_func: Callable[[], int]) -> Tuple[int, int]:
 
     pid = os.fork()
     if pid == 0:
+        os.close(init_pipe[0])
         ret = 0
         try:
             ret = _child_main(None, init_pipe[1], child_func)
@@ -236,6 +240,8 @@ async def _clone_pidfd(child_func: Callable[[], int]) -> Tuple[int, int]:
             ret = -signal.SIGINT
         finally:
             os._exit(ret)
+        return ret
+    os.close(init_pipe[1])
 
     # Get the pidfd.
     fd = os.pidfd_open(pid, 0)  # type: ignore


### PR DESCRIPTION
Sometimes interrupting the process using `aiotools.afork()` hangs due to signal race.
Let's minimize the exposed surface of event loops in the child process.