### PR TITLE
Allow import from windows environment

### DIFF
--- a/changes/47.fix.md
+++ b/changes/47.fix.md
@@ -1,0 +1,1 @@
+Allow importing aiotools on Windows platforms, removing incompatible modules from the default `__all__` import list

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import pkgutil
 
 # Import submodules only when installed properly
 from . import (
@@ -17,13 +18,6 @@ if _is_linux:
         fork as _fork,
         server,
     )
-
-import pkgutil
-_version_data = pkgutil.get_data("aiotools", "VERSION")
-if _version_data is None:
-    __version__ = '0.0.dev'
-else:
-    __version__ = _version_data.decode('utf8').strip()
 
 __all__ = (
     *context.__all__,
@@ -51,3 +45,10 @@ if _is_linux:
 
     from .fork import *        # noqa
     from .server import *      # noqa
+
+
+_version_data = pkgutil.get_data("aiotools", "VERSION")
+if _version_data is None:
+    __version__ = '0.0.dev'
+else:
+    __version__ = _version_data.decode('utf8').strip()

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -1,14 +1,22 @@
+import sys
+
 # Import submodules only when installed properly
 from . import (
     context,
     defer as _defer,
-    fork as _fork,
     func,
     iter as _iter,
-    server,
     taskgroup,
     timer,
 )
+
+_is_linux = sys.platform.startswith('linux')
+
+if _is_linux:
+    from . import (
+        fork as _fork,
+        server,
+    )
 
 import pkgutil
 _version_data = pkgutil.get_data("aiotools", "VERSION")
@@ -20,10 +28,8 @@ else:
 __all__ = (
     *context.__all__,
     *_defer.__all__,
-    *_fork.__all__,
     *func.__all__,
     *_iter.__all__,
-    *server.__all__,
     *taskgroup.__all__,
     *timer.__all__,
     '__version__',
@@ -31,9 +37,17 @@ __all__ = (
 
 from .context import *     # noqa
 from .defer import *       # noqa
-from .fork import *        # noqa
 from .func import *        # noqa
 from .iter import *        # noqa
 from .taskgroup import *   # noqa
 from .timer import *       # noqa
-from .server import *      # noqa
+
+if _is_linux:
+    __all__ = (
+        *__all__,
+        *_fork.__all__,
+        *server.__all__,
+    )
+
+    from .fork import *        # noqa
+    from .server import *      # noqa


### PR DESCRIPTION
`aiotools.fork` raises error for windows.
The comments on fork module say it supports specific version of linux

```
File "c:\users\user\projects\aiotools\src\aiotools\fork.py", line 41, in <module> 
 _libc = ctypes.CDLL(None)  
File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3312.0_x64__qbz5n2kfra8p0\lib\ctypes\__init__.py", line 364, in __init__                                                                                               
  if '/' in name or '\\' in name: 
```