### PR TITLE
fix: Import in macOS (regression from #47)

### DIFF
--- a/changes/49.fix.md
+++ b/changes/49.fix.md
@@ -1,0 +1,1 @@
+Fix regression of the default imports in macOS by removing the unused code that caused the misleading fix in #47

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -11,9 +11,9 @@ from . import (
     timer,
 )
 
-_is_linux = sys.platform.startswith('linux')
+_is_win32 = sys.platform.startswith('win32')
 
-if _is_linux:
+if not _is_win32:
     from . import (
         fork as _fork,
         server,
@@ -36,7 +36,7 @@ from .iter import *        # noqa
 from .taskgroup import *   # noqa
 from .timer import *       # noqa
 
-if _is_linux:
+if not _is_win32:
     __all__ = (
         *__all__,
         *_fork.__all__,

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -5,6 +5,7 @@ import pkgutil
 from . import (
     context,
     defer as _defer,
+    fork as _fork,
     func,
     iter as _iter,
     taskgroup,
@@ -15,13 +16,13 @@ _is_win32 = sys.platform.startswith('win32')
 
 if not _is_win32:
     from . import (
-        fork as _fork,
         server,
     )
 
 __all__ = (
     *context.__all__,
     *_defer.__all__,
+    *_fork.__all__,
     *func.__all__,
     *_iter.__all__,
     *taskgroup.__all__,
@@ -39,7 +40,6 @@ from .timer import *       # noqa
 if not _is_win32:
     __all__ = (
         *__all__,
-        *_fork.__all__,
         *server.__all__,
     )
 

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -29,9 +29,9 @@ from .defer import *       # noqa
 from .fork import *        # noqa
 from .func import *        # noqa
 from .iter import *        # noqa
+from .server import *      # noqa
 from .taskgroup import *   # noqa
 from .timer import *       # noqa
-from .server import *      # noqa
 
 
 _version_data = pkgutil.get_data("aiotools", "VERSION")

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -1,4 +1,3 @@
-import sys
 import pkgutil
 
 # Import submodules only when installed properly
@@ -8,16 +7,10 @@ from . import (
     fork as _fork,
     func,
     iter as _iter,
+    server,
     taskgroup,
     timer,
 )
-
-_is_win32 = sys.platform.startswith('win32')
-
-if not _is_win32:
-    from . import (
-        server,
-    )
 
 __all__ = (
     *context.__all__,
@@ -25,6 +18,7 @@ __all__ = (
     *_fork.__all__,
     *func.__all__,
     *_iter.__all__,
+    *server.__all__,
     *taskgroup.__all__,
     *timer.__all__,
     '__version__',
@@ -32,19 +26,12 @@ __all__ = (
 
 from .context import *     # noqa
 from .defer import *       # noqa
+from .fork import *        # noqa
 from .func import *        # noqa
 from .iter import *        # noqa
 from .taskgroup import *   # noqa
 from .timer import *       # noqa
-
-if not _is_win32:
-    __all__ = (
-        *__all__,
-        *server.__all__,
-    )
-
-    from .fork import *        # noqa
-    from .server import *      # noqa
+from .server import *      # noqa
 
 
 _version_data = pkgutil.get_data("aiotools", "VERSION")

--- a/src/aiotools/fork.py
+++ b/src/aiotools/fork.py
@@ -9,22 +9,11 @@ so that the users may assume that the child process is completely interruptible 
 """
 
 import asyncio
-import ctypes
 import errno
-# import functools
 import logging
 import os
-# import resource
 import signal
 from abc import ABCMeta, abstractmethod
-# from ctypes import (
-#     CFUNCTYPE,
-#     byref,
-#     c_int,
-#     c_char_p,
-#     c_void_p,
-#     cast,
-# )
 from typing import Callable, Tuple
 
 from .compat import get_running_loop
@@ -37,10 +26,6 @@ __all__ = (
 )
 
 logger = logging.getLogger(__name__)
-
-_libc = ctypes.CDLL(None)
-_syscall = _libc.syscall
-_default_stack_size = (8 * (2**20))  # 8 MiB
 
 _has_pidfd = False
 if hasattr(signal, 'pidfd_send_signal'):
@@ -260,51 +245,6 @@ async def _clone_pidfd(child_func: Callable[[], int]) -> Tuple[int, int]:
     os.read(init_pipe[0], 1)
     os.close(init_pipe[0])
     return pid, fd
-
-
-# The below commneted-out version guarantees the PID reusing issue is prevented
-# regardless of SIGCHLD handler configurations.
-# However, in complicated real-world applications, it seems to have some
-# hard-to-debug side effects when cleaning up... :(
-
-# async def _clone_pidfd(child_func: Callable[[], int]) -> Tuple[int, int]:
-#     # reference: os_fork_impl() in the CPython source code
-#     fd = c_int()
-#     loop = get_running_loop()
-#
-#     # prepare the stack memory
-#     stack_size = resource.getrlimit(resource.RLIMIT_STACK)[0]
-#     if stack_size <= 0:
-#         stack_size = _default_stack_size
-#     stack = c_char_p(b"\0" * stack_size)
-#
-#     init_pipe = os.pipe()
-#     init_event = asyncio.Event()
-#     loop.add_reader(init_pipe[0], init_event.set)
-#
-#     func = CFUNCTYPE(c_int)(
-#         functools.partial(
-#             _child_main,
-#             ctypes.pythonapi.PyOS_AfterFork_Child,
-#             init_pipe[1],
-#             child_func,
-#         )
-#     )
-#     stack_top = c_void_p(cast(stack, c_void_p).value + stack_size)  # type: ignore
-#     ctypes.pythonapi.PyOS_BeforeFork()
-#     # The flag value is CLONE_PIDFD from linux/sched.h
-#     pid = _libc.clone(func, stack_top, 0x1000, 0, byref(fd))
-#     ctypes.pythonapi.PyOS_AfterFork_Parent()
-#
-#     # Wait for the child's readiness notification
-#     await init_event.wait()
-#     loop.remove_reader(init_pipe[0])
-#     os.read(init_pipe[0], 1)
-#     os.close(init_pipe[0])
-#
-#     if pid == -1:
-#         raise OSError("failed to fork")
-#     return pid, fd.value
 
 
 async def afork(child_func: Callable[[], int]) -> AbstractChildProcess:


### PR DESCRIPTION
Though `aiotools.fork` and `aiotools.server` modules do not support Windows, importing them is fine.  The previously found error was due to an _unused_ code: `ctypes.CDLL(None)`.

This PR removes those unused codes to avoid confusion and restore the import statements, as #47 has broken imports in macOS.