### PR TITLE
fix: Improve checks for pidfd availability

### DIFF
--- a/changes/51.fix.md
+++ b/changes/51.fix.md
@@ -1,0 +1,1 @@
+Improve checks for pidfd availability to avoid corner cases that may fail on Linux kernel 5.1 and 5.2 where `signal.pidfd_send_signal()` is available but `os.pidfd_open()` is not

--- a/src/aiotools/fork.py
+++ b/src/aiotools/fork.py
@@ -28,11 +28,14 @@ __all__ = (
 logger = logging.getLogger(__name__)
 
 _has_pidfd = False
-if hasattr(signal, 'pidfd_send_signal'):
+if hasattr(os, 'pidfd_open'):
+    # signal.pidfd_send_signal() is available in Linux kernel 5.1+
+    # and os.pidfd_open() is available in Linux kernel 5.3+.
+    # So let's check with os.pidfd_open() which requires higher version.
     try:
-        signal.pidfd_send_signal(0, 0)  # type: ignore
+        os.pidfd_open(0, 0)  # type: ignore
     except OSError as e:
-        if e.errno == errno.EBADF:
+        if e.errno in (errno.EBADF, errno.EINVAL):
             _has_pidfd = True
         # if the kernel does not support this,
         # it will say errno.ENOSYS or errno.EPERM


### PR DESCRIPTION
* Use os.pidfd_open() that requires a higher kernel version to avoid
  a missing API error in Linuxn kernel 5.1 to 5.2.
