### PR TITLE
Fix a potential memory leak in PersistentTaskGroup

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -37,7 +37,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -67,7 +67,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -103,7 +103,7 @@ jobs:
       run: |
         python -m pytest -v --cov=src tests
     - name: Send code coverage report
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         env_vars: GHA_OS,GHA_PYTHON
 
@@ -112,7 +112,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -51,7 +51,6 @@ jobs:
         python -m pip install -U pip setuptools wheel
         python -m pip install -U -r requirements/typecheck.txt
     - name: Type check with mypy
-      continue-on-error: true
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then
           echo "(skipping matchers for pull request from local branches)"
@@ -59,8 +58,6 @@ jobs:
           echo "::add-matcher::.github/workflows/mypy-matcher.json"
         fi
         python -m mypy --no-color-output src/aiotools tests
-    - name: Allow failures
-      run: true
 
   test:
     runs-on: ubuntu-latest

--- a/changes/54.fix.md
+++ b/changes/54.fix.md
@@ -1,0 +1,1 @@
+PersistentTaskGroup no longer stores the history of unhandled exceptions and raises them as an exception group to prevent memory leaks

--- a/src/aiotools/func.py
+++ b/src/aiotools/func.py
@@ -1,5 +1,6 @@
 import collections
 import functools
+from typing import Optional
 
 from .compat import get_running_loop
 
@@ -26,7 +27,7 @@ def apartial(coro, *args, **kwargs):
 
 def lru_cache(maxsize: int = 128,
               typed: bool = False,
-              expire_after: float = None):
+              expire_after: Optional[float] = None):
     """
     A simple LRU cache just like :func:`functools.lru_cache`, but it works for
     coroutines.  This is not as heavily optimized as :func:`functools.lru_cache`

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -408,7 +408,7 @@ def start_server(
     ),
     num_workers: int = 1,
     args: Iterable[Any] = tuple(),
-    wait_timeout: float = None,
+    wait_timeout: Optional[float] = None,
 ) -> None:
     """
     Starts a multi-process server where each process has their own individual

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -17,12 +17,16 @@ else:
     from . import persistent_compat
     from .base_compat import *        # type: ignore  # noqa
     from .persistent_compat import *  # type: ignore  # noqa
-    __all__ = [  # type: ignore
+    from .base_compat import has_contextvars
+    __all__ = [  # type: ignore  # noqa
         "MultiError",
         "TaskGroup",
         "TaskGroupError",
         *persistent_compat.__all__,
     ]
+    if has_contextvars:
+        __all__.append("current_taskgroup")
+
 
 from .utils import as_completed_safe  # noqa
 

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -3,25 +3,24 @@ import asyncio
 from .types import MultiError, TaskGroupError
 
 if hasattr(asyncio, 'TaskGroup'):
-    from . import base
     from . import persistent
     from .base import *        # noqa
     from .persistent import *  # noqa
     __all__ = [
-        'MultiError',
-        'TaskGroupError',
-        *base.__all__,
+        "MultiError",
+        "TaskGroup",
+        "TaskGroupError",
+        "current_taskgroup",
         *persistent.__all__,
     ]
 else:
-    from . import base_compat
     from . import persistent_compat
     from .base_compat import *        # type: ignore  # noqa
     from .persistent_compat import *  # type: ignore  # noqa
     __all__ = [  # type: ignore
-        'MultiError',
-        'TaskGroupError',
-        *base_compat.__all__,
+        "MultiError",
+        "TaskGroup",
+        "TaskGroupError",
         *persistent_compat.__all__,
     ]
 

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -52,8 +52,8 @@ class PersistentTaskGroup:
     def __init__(
         self,
         *,
-        name: str = None,
-        exception_handler: AsyncExceptionHandler = None,
+        name: Optional[str] = None,
+        exception_handler: Optional[AsyncExceptionHandler] = None,
     ) -> None:
         self._entered = False
         self._exiting = False
@@ -82,7 +82,7 @@ class PersistentTaskGroup:
         self,
         coro: Coroutine[Any, Any, Any],
         *,
-        name: str = None,
+        name: Optional[str] = None,
     ) -> Awaitable[Any]:
         if not self._entered:
             # When used as object attribute, auto-enter.
@@ -95,7 +95,7 @@ class PersistentTaskGroup:
         self,
         coro: Coroutine[Any, Any, Any],
         *,
-        name: str = None,
+        name: Optional[str] = None,
         cb: Callable[[asyncio.Task], Any],
     ) -> Awaitable[Any]:
         loop = compat.get_running_loop()

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -222,6 +222,7 @@ class PersistentTaskGroup:
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> Optional[bool]:
+        assert self._parent_task is not None
         self._exiting = True
         propagate_cancellation_error: Optional[
             Union[Type[BaseException], BaseException]

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -10,7 +10,6 @@ from typing import (
     Awaitable,
     Callable,
     Coroutine,
-    List,
     Optional,
     Sequence,
     Type,

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -42,7 +42,6 @@ class PersistentTaskGroup:
 
     _base_error: Optional[BaseException]
     _exc_handler: AsyncExceptionHandler
-    _errors: Optional[List[BaseException]]
     _tasks: "weakref.WeakSet[asyncio.Task]"
     _on_completed_fut: Optional[asyncio.Future]
     _current_taskgroup_token: Optional[Token["PersistentTaskGroup"]]
@@ -60,7 +59,6 @@ class PersistentTaskGroup:
         self._entered = False
         self._exiting = False
         self._aborting = False
-        self._errors = []
         self._base_error = None
         self._name = name or f"{next(_ptaskgroup_idx)}"
         self._parent_cancel_requested = False
@@ -192,7 +190,6 @@ class PersistentTaskGroup:
         self._unfinished_tasks -= 1
         assert self._unfinished_tasks >= 0
         assert self._parent_task is not None
-        assert self._errors is not None
 
         if self._on_completed_fut is not None and not self._unfinished_tasks:
             if not self._on_completed_fut.done():
@@ -207,7 +204,6 @@ class PersistentTaskGroup:
             return
 
         # Now the exception is BaseException.
-        self._errors.append(exc)
         if self._base_error is None:
             self._base_error = exc
 
@@ -228,7 +224,6 @@ class PersistentTaskGroup:
         exc_tb: Optional[TracebackType],
     ) -> Optional[bool]:
         self._exiting = True
-        assert self._errors is not None
         propagate_cancellation_error: Optional[
             Union[Type[BaseException], BaseException]
         ] = None
@@ -263,23 +258,6 @@ class PersistentTaskGroup:
         if propagate_cancellation_error is not None:
             raise propagate_cancellation_error
 
-        if exc_val is not None and exc_type is not asyncio.CancelledError:
-            # If there are any unhandled errors, let's add them to
-            # the bubbled up exception group.
-            # Normally, they should have been swallowed and logged
-            # by the fallback exception handler.
-            self._errors.append(exc_val)
-
-        if self._errors:
-            # Bubble up errors
-            errors = self._errors
-            self._errors = None
-            me = BaseExceptionGroup(
-                'unhandled errors in a PersistentTaskGroup',
-                errors,
-            )
-            raise me from None
-
         return None
 
     def __repr__(self) -> str:
@@ -290,8 +268,6 @@ class PersistentTaskGroup:
             info.append(f'tasks={len(self._tasks)}')
         if self._unfinished_tasks:
             info.append(f'unfinished={self._unfinished_tasks}')
-        if self._errors:
-            info.append(f'errors={len(self._errors)}')
         if self._aborting:
             info.append('cancelling')
         elif self._entered:

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -14,7 +14,6 @@ from typing import (
     Awaitable,
     Callable,
     Coroutine,
-    List,
     Optional,
     Sequence,
     Type,
@@ -23,7 +22,7 @@ import weakref
 
 from .. import compat
 from .common import create_task_with_name, patch_task
-from .types import AsyncExceptionHandler, TaskGroupError
+from .types import AsyncExceptionHandler
 
 __all__ = [
     'PersistentTaskGroup',

--- a/src/aiotools/taskgroup/persistent_compat.py
+++ b/src/aiotools/taskgroup/persistent_compat.py
@@ -57,8 +57,8 @@ class PersistentTaskGroup:
     def __init__(
         self,
         *,
-        name: str = None,
-        exception_handler: AsyncExceptionHandler = None,
+        name: Optional[str] = None,
+        exception_handler: Optional[AsyncExceptionHandler] = None,
     ) -> None:
         self._entered = False
         self._exiting = False
@@ -87,7 +87,7 @@ class PersistentTaskGroup:
         self,
         coro: Coroutine[Any, Any, Any],
         *,
-        name: str = None,
+        name: Optional[str] = None,
     ) -> Awaitable[Any]:
         if not self._entered:
             # When used as object attribute, auto-enter.
@@ -100,7 +100,7 @@ class PersistentTaskGroup:
         self,
         coro: Coroutine[Any, Any, Any],
         *,
-        name: str = None,
+        name: Optional[str] = None,
         cb: Callable[[asyncio.Task], Any],
     ) -> Awaitable[Any]:
         loop = compat.get_running_loop()

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -26,7 +26,7 @@ class AsyncExceptionHandler(Protocol):
 
 if not hasattr(builtins, 'ExceptionGroup'):
 
-    class MultiError(Exception):
+    class MultiError(Exception):  # type: ignore[no-redef]
 
         def __init__(self, msg, errors=()):
             if errors:
@@ -47,7 +47,7 @@ if not hasattr(builtins, 'ExceptionGroup'):
         def __reduce__(self):
             return (type(self), (self.args,), {'__errors__': self.__errors__})
 
-    class TaskGroupError(MultiError):
+    class TaskGroupError(MultiError):  # type: ignore[no-redef]
         """
         An alias to :exc:`MultiError`.
         """
@@ -55,7 +55,7 @@ if not hasattr(builtins, 'ExceptionGroup'):
 
 else:
 
-    class MultiError(ExceptionGroup):
+    class MultiError(ExceptionGroup):  # type: ignore[no-redef]
 
         def __init__(self, msg, errors=()):
             super().__init__(msg, errors)
@@ -64,5 +64,5 @@ else:
         def get_error_types(self):
             return {type(e) for e in self.exceptions}
 
-    class TaskGroupError(MultiError):
+    class TaskGroupError(MultiError):  # type: ignore[no-redef]
         pass


### PR DESCRIPTION
- It no longer stores the unhandled exceptions from subtasks,
  as they will be kept for the whole lifespan of the
  PersistentTaskGroup.
