### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,10 +12,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version:
         - "3.11"
-        experimental: [false]
-        include:
-        - python-version: "~3.12.0-0"
-          experimental: true
+        - "3.12"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ celerybeat-schedule
 .envrc
 
 # virtualenv
+.venv/
 venv/
 ENV/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 23.7.0
+  rev: 23.9.1
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/changes/64.feature.md
+++ b/changes/64.feature.md
@@ -1,0 +1,1 @@
+Add Python 3.12 support

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ build =
     twine~=4.0
     towncrier~=22.12
 test =
-    pytest~=7.2.2
+    pytest~=7.4.2
     pytest-asyncio~=0.21
     pytest-cov
     pytest-mock
@@ -53,7 +53,7 @@ lint =
     ruff>=0.0.285
     ruff-lsp>=0.0.37
 typecheck =
-    mypy~=1.4.1
+    mypy~=1.5.1
 docs =
     sphinx~=4.3
     sphinx-rtd-theme~=1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development
 url = https://github.com/achimnol/aiotools
 project_urls =

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -229,6 +229,7 @@ main = _main_ctxmgr
 
 def setup_child_watcher(loop: asyncio.AbstractEventLoop) -> None:
     if sys.version_info < (3, 12, 0):
+        # see python/cpython#94597 (issue) and python/cpython#98215 (pr)
         try:
             watcher_cls = getattr(asyncio, "PidfdChildWatcher", None)
             if _has_pidfd and watcher_cls:

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -228,18 +228,19 @@ main = _main_ctxmgr
 
 
 def setup_child_watcher(loop: asyncio.AbstractEventLoop) -> None:
-    try:
-        watcher_cls = getattr(asyncio, "PidfdChildWatcher", None)
-        if _has_pidfd and watcher_cls:
-            watcher = watcher_cls()
-            asyncio.set_child_watcher(watcher)
-        else:
-            # Just get the default child watcher.
-            watcher = asyncio.get_child_watcher()
-        if not watcher.is_active():
-            watcher.attach_loop(loop)
-    except NotImplementedError:
-        pass  # for uvloop
+    if sys.version_info < (3, 12, 0):
+        try:
+            watcher_cls = getattr(asyncio, "PidfdChildWatcher", None)
+            if _has_pidfd and watcher_cls:
+                watcher = watcher_cls()
+                asyncio.set_child_watcher(watcher)
+            else:
+                # Just get the default child watcher.
+                watcher = asyncio.get_child_watcher()
+            if not watcher.is_active():
+                watcher.attach_loop(loop)
+        except NotImplementedError:
+            pass  # for uvloop
 
 
 async def cancel_all_tasks() -> None:

--- a/src/aiotools/taskgroup/types.py
+++ b/src/aiotools/taskgroup/types.py
@@ -14,8 +14,7 @@ class AsyncExceptionHandler(Protocol):
         exc_type: type[Exception],
         exc_obj: Exception,
         exc_tb: TracebackType,
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 class MultiError(ExceptionGroup):

--- a/src/aiotools/types.py
+++ b/src/aiotools/types.py
@@ -17,8 +17,7 @@ _T = TypeVar("_T")
 
 @runtime_checkable
 class AsyncClosable(Protocol):
-    async def close(self) -> None:
-        ...
+    async def close(self) -> None: ...
 
 
 # taken from the typeshed


### PR DESCRIPTION
There seems to be no breaking changes yet.
Though, child watchers are going to be deprecated so let's just skip manual configuration of them. (python/cpython#94597)