### PR TITLE
Add Python 3.13 compatibility

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,9 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.13"
 python:
   install:
   - requirements: requirements/docs.txt

--- a/changes/71.feature
+++ b/changes/71.feature
@@ -1,0 +1,1 @@
+Add Python 3.13 compatibility

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,8 @@ lint =
 typecheck =
     mypy~=1.8.0
 docs =
-    sphinx~=4.3
-    sphinx-rtd-theme~=1.0
+    sphinx~=8.1.3
+    sphinx-rtd-theme~=3.0.2
 
 [options.packages.find]
 where = src

--- a/src/aiotools/compat.py
+++ b/src/aiotools/compat.py
@@ -1,5 +1,24 @@
 import asyncio
+import warnings
 
 get_running_loop = asyncio.get_running_loop
 all_tasks = asyncio.all_tasks
 current_task = asyncio.current_task
+
+
+def set_task_name(task, name):
+    # This compatibility function had been in asyncio.tasks until Python 3.12,
+    # but removed since Python 3.13.
+    if name is not None:
+        try:
+            set_name = task.set_name
+        except AttributeError:
+            warnings.warn(
+                "Task.set_name() was added in Python 3.8, "
+                "the method support will be mandatory for third-party "
+                "task implementations since 3.13.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        else:
+            set_name(name)

--- a/src/aiotools/compat.py
+++ b/src/aiotools/compat.py
@@ -14,11 +14,9 @@ def set_task_name(task, name):
             set_name = task.set_name
         except AttributeError:
             warnings.warn(
-                "Task.set_name() was added in Python 3.8, "
-                "the method support will be mandatory for third-party "
-                "task implementations since 3.13.",
+                "Task name customization may not be available in 3rd-party event loops before Python 3.13",
                 DeprecationWarning,
-                stacklevel=3,
+                stacklevel=2,
             )
         else:
             set_name(name)

--- a/src/aiotools/supervisor.py
+++ b/src/aiotools/supervisor.py
@@ -118,7 +118,6 @@ class Supervisor:
             task = self._loop.create_task(coro)
         else:
             task = self._loop.create_task(coro, context=context)
-        task.set_name(name)
         set_task_name(task, name)
         task.add_done_callback(self._on_task_done)
         self._tasks.add(task)

--- a/src/aiotools/supervisor.py
+++ b/src/aiotools/supervisor.py
@@ -1,6 +1,8 @@
 from asyncio import events, exceptions, tasks
 from typing import Optional
 
+from .compat import set_task_name
+
 __all__ = ["Supervisor"]
 
 
@@ -116,7 +118,8 @@ class Supervisor:
             task = self._loop.create_task(coro)
         else:
             task = self._loop.create_task(coro, context=context)
-        tasks._set_task_name(task, name)
+        task.set_name(name)
+        set_task_name(task, name)
         task.add_done_callback(self._on_task_done)
         self._tasks.add(task)
         return task


### PR DESCRIPTION
`asyncio.tasks._set_task_name()` is now removed as Python 3.13 mandates all 3rd-party event loop implementations to provide `Task.set_name()` method.
Since we have to support prior Python versions, copy the same logic into our `compat` module.
