### PR TITLE
Make public exports of `aiotools.taskgroup` static-checker friendly

### DIFF
--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -8,11 +8,11 @@ jobs:
     if: |
       !contains(github.event.pull_request.labels.*.name, 'skip:changelog')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: "pip"

--- a/changes/72.fix
+++ b/changes/72.fix
@@ -1,0 +1,1 @@
+Fix static type checker's recognition of `aiotools.taskgroup` public exports, such as `aiotools.PersistentTaskGroup`

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "as_completed_safe",
     "persistent",
     "persistent_compat",
+    "current_taskgroup",
     "current_ptaskgroup",
     "has_contextvars",
 ]

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -2,34 +2,26 @@ import asyncio
 
 from .types import MultiError, TaskGroupError
 
+__all__ = [
+    "MultiError",
+    "TaskGroup",
+    "TaskGroupError",
+    "PersistentTaskGroup",
+    "as_completed_safe",
+    "persistent",
+    "persistent_compat",
+    "current_taskgroup",
+    "has_contextvars",
+]
+
 if hasattr(asyncio, "TaskGroup"):
     from . import persistent
     from .base import *  # noqa
     from .persistent import *  # noqa
-
-    __all__ = [
-        "MultiError",
-        "TaskGroup",
-        "TaskGroupError",
-        "current_taskgroup",
-        *persistent.__all__,
-    ]
 else:
     from . import persistent_compat
     from .base_compat import *  # type: ignore  # noqa
     from .base_compat import has_contextvars
     from .persistent_compat import *  # type: ignore  # noqa
 
-    __all__ = [  # type: ignore  # noqa
-        "MultiError",
-        "TaskGroup",
-        "TaskGroupError",
-        *persistent_compat.__all__,
-    ]
-    if has_contextvars:
-        __all__.append("current_taskgroup")
-
-
 from .utils import as_completed_safe  # noqa
-
-__all__.append("as_completed_safe")

--- a/src/aiotools/taskgroup/__init__.py
+++ b/src/aiotools/taskgroup/__init__.py
@@ -10,7 +10,7 @@ __all__ = [
     "as_completed_safe",
     "persistent",
     "persistent_compat",
-    "current_taskgroup",
+    "current_ptaskgroup",
     "has_contextvars",
 ]
 
@@ -18,6 +18,8 @@ if hasattr(asyncio, "TaskGroup"):
     from . import persistent
     from .base import *  # noqa
     from .persistent import *  # noqa
+
+    has_contextvars = True
 else:
     from . import persistent_compat
     from .base_compat import *  # type: ignore  # noqa


### PR DESCRIPTION
After 1.8.0 release, the following code began to generate mypy errors like `Name "aiotools.PersistentTaskGroup" is not defined  [name-defined]`.
This PR updates the declaration of `aiotools.taskgroup.__all__` to be more static-checker friendly, removing no-longer-required branches for pre-3.7 Python versions.

```python
import aiotools

async def something():
    async with aiotools.PersistentTaskGroup() as tg:  # <--
        ...
```
