### PR TITLE
doc: Remove deprecated `loop=loop` kwarg in README example

### DIFF
--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -1,6 +1,8 @@
 name: timeline-check
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
 
 jobs:
   towncrier:

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ async def echo(reader, writer):
 
 @aiotools.server
 async def myworker(loop, pidx, args):
-   server = await asyncio.start_server(echo, '0.0.0.0', 8888,
-       reuse_port=True, loop=loop)
+   server = await asyncio.start_server(echo, '0.0.0.0', 8888, reuse_port=True)
    print(f'[{pidx}] started')
    yield  # wait until terminated
    server.close()


### PR DESCRIPTION
resolves #77
