### PR TITLE
fix: Override `loop._clock_resolution` with a coarse-grained value in VirtualClock

### DIFF
--- a/changes/81.fix
+++ b/changes/81.fix
@@ -1,0 +1,1 @@
+Explicitly override `loop._clock_resolution` with a coarse-grained value to prevent getting stuck when using VirtualClock with a realistic timestamp due to the floating point precision issue

--- a/src/aiotools/timer.py
+++ b/src/aiotools/timer.py
@@ -110,6 +110,11 @@ class VirtualClock:
             ),
             mock.patch.object(
                 loop,
+                "_clock_resolution",
+                new=0.001,
+            ),
+            mock.patch.object(
+                loop,
                 "time",
                 new=self.virtual_time,
             ),

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -143,3 +143,13 @@ async def test_timer_leak_nocancel():
         assert spawn_count == cancel_count + done_count
         assert cancel_count == 0
         assert done_count == 10
+
+
+@pytest.mark.asyncio
+async def test_timer_stuck_forever():
+    # See achimnol/aiotools#69
+    # (https://github.com/achimnol/aiotools/issues/69)
+    vclock = aiotools.VirtualClock()
+    vclock.vtime = 1709591365
+    with vclock.patch_loop():
+        await asyncio.sleep(1)


### PR DESCRIPTION
resolves #69
