### PR TITLE
Fix windows support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
         - "3.11"
         - "3.12"


### PR DESCRIPTION
Attempt to fix:

```
E   AttributeError: module 'multiprocessing.context' has no attribute 'ForkProcess'
E   Falsifying example: test_mapper_exception_hypothesis(
E       # The test always failed when commented parts were varied together.
E       create_mapper=datachain.asyn.OrderedMapper,
E       inputs=[(True, 0)],  # or any other generated value
E       workers=1,  # or any other generated value

....

C:\a\datachain\datachain\tests\unit\test_asyn.py:192: in test_mapper_hypothesis
    with mock_time(loop):
C:\Users\runneradmin\AppData\Roaming\uv\python\cpython-3.9.22-windows-x86_64-none\lib\contextlib.py:119: in __enter__
    return next(self.gen)
C:\a\datachain\datachain\tests\unit\test_asyn.py:39: in mock_time
    from aiotools import VirtualClock
C:\a\datachain\datachain\.nox\tests-3-9\lib\site-packages\aiotools\__init__.py:4: in <module>
    from . import (
C:\a\datachain\datachain\.nox\tests-3-9\lib\site-packages\aiotools\server.py:56: in <module>
    from .fork import AbstractChildProcess, MPContext, _has_pidfd, afork
```

we started hitting on CI/CD today after the 1.9.0 release.

Also (optionally) enable test on Windows. Probably though they were disabled for a reason.