### PR TITLE
Allow importing aiotools in Windows CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
         - "3.11"
         - "3.12"

--- a/changes/84.fix.md
+++ b/changes/84.fix.md
@@ -1,0 +1,1 @@
+Allow importing aiotools in the Windows CI by using Windows-specific type definitions while disabling fork/server tests

--- a/src/aiotools/fork.py
+++ b/src/aiotools/fork.py
@@ -24,6 +24,7 @@ import multiprocessing.connection as mpc
 import multiprocessing.context as mpctx
 import os
 import signal
+import sys
 import traceback
 from abc import ABCMeta, abstractmethod
 from typing import Callable, ClassVar, Optional, Tuple, TypeAlias
@@ -39,15 +40,20 @@ __all__ = (
 
 logger = logging.getLogger(__name__)
 
-MPProcess: TypeAlias = (
-    mpctx.Process | mpctx.SpawnProcess | mpctx.ForkProcess | mpctx.ForkServerProcess
-)
-MPContext: TypeAlias = (
-    mpctx.DefaultContext
-    | mpctx.ForkContext
-    | mpctx.ForkServerContext
-    | mpctx.SpawnContext
-)
+if sys.platform != "win32":
+    MPProcess: TypeAlias = (
+        mpctx.Process | mpctx.SpawnProcess | mpctx.ForkProcess | mpctx.ForkServerProcess
+    )
+    MPContext: TypeAlias = (
+        mpctx.DefaultContext
+        | mpctx.ForkContext
+        | mpctx.ForkServerContext
+        | mpctx.SpawnContext
+    )
+
+else:
+    MPProcess: TypeAlias = mpctx.Process | mpctx.SpawnProcess
+    MPContext: TypeAlias = mpctx.DefaultContext | mpctx.SpawnContext
 
 _has_pidfd = False
 if hasattr(os, "pidfd_open"):

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -2,6 +2,7 @@ import asyncio
 import multiprocessing as mp
 import os
 import signal
+import sys
 import time
 from unittest import mock
 
@@ -9,6 +10,13 @@ import pytest
 
 from aiotools import fork as fork_mod
 from aiotools.fork import MPContext, PidfdChildProcess, _has_pidfd, afork
+
+if sys.platform == "win32":
+    pytest.skip(
+        "forks tests not supported on Windows",
+        allow_module_level=True,
+    )
+
 
 target_mp_contexts = [
     pytest.param(mp.get_context(method), id=method)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,6 +23,12 @@ if os.environ.get("CI", "") and sys.version_info < (3, 9, 0):
         allow_module_level=True,
     )
 
+if sys.platform == "win32":
+    pytest.skip(
+        "server tests not supported on Windows",
+        allow_module_level=True,
+    )
+
 target_mp_contexts = [
     pytest.param(mp.get_context(method), id=method)
     for method in mp.get_all_start_methods()


### PR DESCRIPTION
Attempt to fix init broken on Windows now (hurts our CI/CD). Also (optionally) enable test on Windows. Probably though they were disabled for a reason. Let me know - I can disable it back.

We started hitting the issue after the 1.9.0 release.

```python
E   AttributeError: module 'multiprocessing.context' has no attribute 'ForkProcess'
E   Falsifying example: test_mapper_exception_hypothesis(
E       # The test always failed when commented parts were varied together.
E       create_mapper=datachain.asyn.OrderedMapper,
E       inputs=[(True, 0)],  # or any other generated value
E       workers=1,  # or any other generated value
....
```

```python
C:\a\datachain\datachain\tests\unit\test_asyn.py:192: in test_mapper_hypothesis
    with mock_time(loop):
C:\Users\runneradmin\AppData\Roaming\uv\python\cpython-3.9.22-windows-x86_64-none\lib\contextlib.py:119: in __enter__
    return next(self.gen)
C:\a\datachain\datachain\tests\unit\test_asyn.py:39: in mock_time
    from aiotools import VirtualClock
C:\a\datachain\datachain\.nox\tests-3-9\lib\site-packages\aiotools\__init__.py:4: in <module>
    from . import (
C:\a\datachain\datachain\.nox\tests-3-9\lib\site-packages\aiotools\server.py:56: in <module>
    from .fork import AbstractChildProcess, MPContext, _has_pidfd, afork
```