### PR TITLE
feat: Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         - "3.11"
         - "3.12"
         - "3.13"
+        - "3.14"
+        - "3.14t"
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout the source tree

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ TaskScope does not store any exceptions or results by itself.
 See also high-level coroutine utilities such as `as_completed_safe()`,
 `gather_safe()`, and `race()` functions in the utils module.
 
+TaskScope itself and these utilities integrate with
+[the call-graph inspection](https://docs.python.org/3/library/asyncio-graph.html)
+introduced in Python 3.14.
+
 
 ### Async Timer
 

--- a/changes/91.feature.md
+++ b/changes/91.feature.md
@@ -1,1 +1,1 @@
-Support Python 3.14 including `TaskScope` integration with asyncio's new call-graph inspection and updated signature of allowing arbitrary kwargs in `create_task()`
+Support Python 3.14 including `TaskScope` integration with asyncio's new call-graph inspection, updated signature of allowing arbitrary kwargs in `create_task()`, and improved support for the new default "forkserver" start method of multiprocessing in `afork()` and `start_server()`

--- a/changes/91.feature.md
+++ b/changes/91.feature.md
@@ -1,0 +1,1 @@
+Support Python 3.14 including `TaskScope` integration with asyncio's new call-graph inspection and updated signature of allowing arbitrary kwargs in `create_task()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ dev = [
     "coverage>=7.10.7",
     "mypy>=1.18.2",
     "pre-commit>=4.3.0",
+    "pystack>=1.5.1",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ dev = [
     "coverage>=7.10.7",
     "mypy>=1.18.2",
     "pre-commit>=4.3.0",
-    "pystack>=1.5.1",
+    "pystack>=1.5.1 ; sys_platform == 'linux'",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
 ]
 

--- a/src/aiotools/fork.py
+++ b/src/aiotools/fork.py
@@ -282,8 +282,6 @@ def _child_main(
         ret = -signal.SIGTERM
     except Exception:
         traceback.print_exc()
-    finally:
-        os._exit(ret)
     return ret
 
 

--- a/src/aiotools/fork.py
+++ b/src/aiotools/fork.py
@@ -282,7 +282,8 @@ def _child_main(
         ret = -signal.SIGTERM
     except Exception:
         traceback.print_exc()
-    return ret
+    finally:
+        os._exit(ret)
 
 
 async def _fork_posix(

--- a/src/aiotools/fork.py
+++ b/src/aiotools/fork.py
@@ -41,7 +41,7 @@ __all__ = (
     "afork",
 )
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__spec__.name)
 
 if sys.platform != "win32":
     MPProcess: TypeAlias = (
@@ -132,7 +132,7 @@ class PosixChildProcess(AbstractChildProcess):
     def send_signal(self, signum: int) -> None:
         if self._terminated:
             if signum != signal.SIGKILL:
-                logger.warning(
+                log.warning(
                     "PosixChildProcess(%d).send_signal(%d): "
                     "The process has already terminated.",
                     self._pid,
@@ -140,11 +140,11 @@ class PosixChildProcess(AbstractChildProcess):
                 )
             return
         if signum == signal.SIGKILL:
-            logger.warning("Force-killed hanging child: %d", self._pid)
+            log.warning("Force-killed hanging child: %d", self._pid)
         try:
             os.kill(self._pid, signum)
         except ProcessLookupError:
-            logger.warning(
+            log.warning(
                 "PosixChildProcess(%d).send_signal(%d): "
                 "The process has already terminated.",
                 self._pid,
@@ -162,10 +162,13 @@ class PosixChildProcess(AbstractChildProcess):
                         break
                     await asyncio.sleep(self.poll_interval)
             except ChildProcessError:
-                # Since we have already checked for the process's existence,
-                # we can assume that the process has terminated.
-                self._returncode = 255
-        self._proc.join()  # let multiprocessing clean up itself
+                # The child process may have already terminated.
+                self._proc.join()  # let multiprocessing retrieve its tracked exit code
+                self._returncode = (
+                    self._proc.exitcode if self._proc.exitcode is not None else 255
+                )
+            else:
+                self._proc.join()  # let multiprocessing clean up itself
         self._terminated = True
         return self._returncode
 
@@ -198,7 +201,7 @@ class PidfdChildProcess(AbstractChildProcess):
     def send_signal(self, signum: int) -> None:
         if self._terminated:
             if signum != signal.SIGKILL:
-                logger.warning(
+                log.warning(
                     "PidfdChildProcess(%d, %d).send_signal(%d): "
                     "The process has already terminated.",
                     self._pid,
@@ -207,7 +210,7 @@ class PidfdChildProcess(AbstractChildProcess):
                 )
             return
         if signum == signal.SIGKILL:
-            logger.warning("Force-killed hanging child: %d", self._pid)
+            log.warning("Force-killed hanging child: %d", self._pid)
         signal.pidfd_send_signal(self._pidfd, signum)  # type: ignore
 
     def _do_wait(self) -> None:
@@ -223,8 +226,11 @@ class PidfdChildProcess(AbstractChildProcess):
         except ChildProcessError:
             # The child process is already reaped
             # (may happen if waitpid() is called elsewhere).
-            self._returncode = 255
-            logger.warning(
+            self._proc.join()  # let multiprocessing retrieve its exit code
+            self._returncode = (
+                self._proc.exitcode if self._proc.exitcode is not None else 255
+            )
+            log.warning(
                 "child process %d exit status already read: "
                 "it will report returncode 255",
                 self._pid,
@@ -240,7 +246,7 @@ class PidfdChildProcess(AbstractChildProcess):
             elif status_info.si_code == os.CLD_DUMPED:
                 self._returncode = -status_info.si_status  # signal number
             else:
-                logger.warning(
+                log.warning(
                     "unexpected si_code %d and si_status %d for child process %d",
                     status_info.si_code,
                     status_info.si_status,
@@ -250,7 +256,6 @@ class PidfdChildProcess(AbstractChildProcess):
         finally:
             loop.remove_reader(self._pidfd)
             os.close(self._pidfd)
-            self._proc.join()  # let multiprocessing clean up itself
             self._terminated = True
             self._wait_event.set()
 

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -60,7 +60,7 @@ __all__ = (
     "InterruptedBySignal",
 )
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__spec__.name)
 
 process_index: ContextVar[int] = ContextVar("process_index")
 

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -47,9 +47,8 @@ from contextvars import ContextVar
 from types import TracebackType
 from typing import Any, ParamSpec, TypeVar
 
-from .compat import all_tasks, current_task, get_running_loop
 from .context import AbstractAsyncContextManager
-from .fork import AbstractChildProcess, MPContext, _has_pidfd, afork
+from .fork import AbstractChildProcess, MPContext, afork
 
 __all__ = (
     "main_context",
@@ -274,42 +273,6 @@ def main_context(
     return helper
 
 
-def setup_child_watcher(loop: asyncio.AbstractEventLoop) -> None:
-    if sys.version_info < (3, 12, 0):
-        # see python/cpython#94597 (issue) and python/cpython#98215 (pr)
-        try:
-            watcher_cls = getattr(asyncio, "PidfdChildWatcher", None)
-            if _has_pidfd and watcher_cls:
-                watcher = watcher_cls()
-                asyncio.set_child_watcher(watcher)
-            else:
-                # Just get the default child watcher.
-                watcher = asyncio.get_child_watcher()
-            if not watcher.is_active():
-                watcher.attach_loop(loop)
-        except NotImplementedError:
-            pass  # for uvloop
-
-
-async def cancel_all_tasks() -> None:
-    loop = get_running_loop()
-    cancelled_tasks: list[asyncio.Task[Any]] = []
-    for task in all_tasks():
-        if not task.done() and task is not current_task():
-            task.cancel()
-            cancelled_tasks.append(task)
-    await asyncio.gather(*cancelled_tasks, return_exceptions=True)
-    for task in cancelled_tasks:
-        if task.cancelled():
-            continue
-        if task.exception() is not None:
-            loop.call_exception_handler({
-                "message": "unhandled exception during loop shutdown",
-                "exception": task.exception(),
-                "task": task,
-            })
-
-
 def _get_default_stop_signal(
     stop_signals: Collection[signal.Signals],
 ) -> signal.Signals:
@@ -334,31 +297,31 @@ def _worker_main(
     process_index.set(proc_idx)
     if prestart_hook:
         prestart_hook(proc_idx)
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    setup_child_watcher(loop)
-    interrupted = asyncio.Event()
-    ctx = worker_actxmgr(loop, proc_idx, args)
-    forever_future: asyncio.Future[None] = loop.create_future()
-
-    def handle_stop_signal(signum: signal.Signals) -> None:
-        if interrupted.is_set():
-            pass
-        else:
-            interrupted.set()
-            ctx.yield_return = signum
-            forever_future.cancel()
-
-    for signum in stop_signals:
-        loop.add_signal_handler(
-            signum,
-            functools.partial(handle_stop_signal, signum),
-        )
-    # Allow the worker to be interrupted during initialization
-    # (in case of initialization failures in other workers)
-    signal.pthread_sigmask(signal.SIG_UNBLOCK, stop_signals)
 
     async def _wrapped_worker() -> None:
+        loop = asyncio.get_running_loop()
+
+        def handle_stop_signal(signum: signal.Signals) -> None:
+            if interrupted.is_set():
+                pass
+            else:
+                interrupted.set()
+                ctx.yield_return = signum
+                forever_future.cancel()
+
+        for signum in stop_signals:
+            loop.add_signal_handler(
+                signum,
+                functools.partial(handle_stop_signal, signum),
+            )
+        interrupted = asyncio.Event()
+        ctx = worker_actxmgr(loop, proc_idx, args)
+        forever_future: asyncio.Future[None] = loop.create_future()
+
+        # Allow the worker to be interrupted during initialization
+        # (in case of initialization failures in other workers)
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, stop_signals)
+
         err_ctx = "enter"
         try:
             async with ctx:
@@ -386,19 +349,8 @@ def _worker_main(
         finally:
             intr_write_pipe.close()
 
-    try:
-        loop.run_until_complete(_wrapped_worker())
-    finally:
-        try:
-            loop.run_until_complete(cancel_all_tasks())
-            loop.run_until_complete(loop.shutdown_asyncgens())
-            try:
-                loop.run_until_complete(loop.shutdown_default_executor())
-            except (AttributeError, NotImplementedError):  # for uvloop
-                pass
-        finally:
-            loop.close()
-        return 0
+    asyncio.run(_wrapped_worker())
+    return 0
 
 
 def _extra_main(
@@ -444,7 +396,7 @@ def _extra_main(
     finally:
         # same as in _worker_main()
         signal.pthread_sigmask(signal.SIG_BLOCK, stop_signals)
-        return 0
+    return 0
 
 
 def start_server(
@@ -646,64 +598,60 @@ def start_server(
     # temporarily block signals and register signal handlers to main_loop
     signal.pthread_sigmask(signal.SIG_BLOCK, sigblock_mask)
 
-    main_loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(main_loop)
-    main_future: asyncio.Future[None] = main_loop.create_future()
+    async def _parent_main() -> None:
+        main_loop = asyncio.get_running_loop()
+        main_future: asyncio.Future[None] = main_loop.create_future()
 
-    # to make subprocess working in child threads
-    setup_child_watcher(main_loop)
+        # Build a main-to-worker interrupt channel using signals
+        def handle_stop_signal(signum: signal.Signals) -> None:
+            main_ctx.yield_return = signum
+            for child in children:
+                child.send_signal(signum)
+            # instead of main_loop.stop(), we use a future here
+            # NOT to interrupt the cleanup routines in
+            # an arbitrary timing upon async child failures.
+            main_future.cancel()
 
-    # Build a main-to-worker interrupt channel using signals
-    def handle_stop_signal(signum: signal.Signals) -> None:
-        main_ctx.yield_return = signum
-        for child in children:
-            child.send_signal(signum)
-        # instead of main_loop.stop(), we use a future here
-        # NOT to interrupt the cleanup routines in
-        # an arbitrary timing upon async child failures.
-        main_future.cancel()
+        for signum in stop_signals:
+            main_loop.add_signal_handler(
+                signum,
+                functools.partial(handle_stop_signal, signum),
+            )
 
-    for signum in stop_signals:
-        main_loop.add_signal_handler(
-            signum,
-            functools.partial(handle_stop_signal, signum),
-        )
+        # Build a reliable worker-to-main interrupt channel using a pipe.
+        # This channel is used when the worker main functions raise an unhandled exception,
+        # so that the main program can be interrupted immediately.
+        def handle_child_interrupt(read_pipe: mpconn.Connection) -> None:
+            try:
+                child_idx: int = struct.unpack("i", read_pipe.recv_bytes(4))[0]
+            except EOFError:
+                # read_pipe is already closed
+                return
+            if not ignore_child_interrupts and not run_to_completion:
+                # self-interrupt to initiate the main-to-worker interrupts
+                log.debug(f"Child {child_idx} has interrupted the main program.")
+                signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT})
+                os.kill(0, signal.SIGINT)
 
-    # Build a reliable worker-to-main interrupt channel using a pipe.
-    # This channel is used when the worker main functions raise an unhandled exception,
-    # so that the main program can be interrupted immediately.
-    def handle_child_interrupt(read_pipe: mpconn.Connection) -> None:
+        read_pipe, write_pipe = mp.Pipe()
+        main_loop.add_reader(read_pipe.fileno(), handle_child_interrupt, read_pipe)
+
+        # start
         try:
-            child_idx: int = struct.unpack("i", read_pipe.recv_bytes(4))[0]
-        except EOFError:
-            # read_pipe is already closed
-            return
-        if not ignore_child_interrupts and not run_to_completion:
-            # self-interrupt to initiate the main-to-worker interrupts
-            log.debug(f"Child {child_idx} has interrupted the main program.")
-            signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT})
-            os.kill(0, signal.SIGINT)
+            with main_ctx as main_args:
+                # retrieve args generated by the user-defined main
+                main_args_tuple: tuple[Any, ...]
+                if main_args is None:
+                    main_args_tuple = tuple()
+                elif not isinstance(main_args, tuple):
+                    main_args_tuple = (main_args,)
+                else:
+                    main_args_tuple = main_args
 
-    read_pipe, write_pipe = mp.Pipe()
-    main_loop.add_reader(read_pipe.fileno(), handle_child_interrupt, read_pipe)
-
-    # start
-    try:
-        with main_ctx as main_args:
-            # retrieve args generated by the user-defined main
-            main_args_tuple: tuple[Any, ...]
-            if main_args is None:
-                main_args_tuple = tuple()
-            elif not isinstance(main_args, tuple):
-                main_args_tuple = (main_args,)
-            else:
-                main_args_tuple = main_args
-
-            # spawn managed async workers
-            for i in range(num_workers):
-                try:
-                    p = main_loop.run_until_complete(
-                        afork(
+                # spawn managed async workers
+                for i in range(num_workers):
+                    try:
+                        p = await afork(
                             functools.partial(
                                 _worker_main,
                                 worker_actxmgr,
@@ -716,23 +664,21 @@ def start_server(
                             ),
                             mp_context=mp_context,
                         )
-                    )
-                except RuntimeError as e:
-                    if "loop stopped" in e.args[0]:
-                        log.warning(
-                            "skipping spawning of child[worker]:%d due to "
-                            "async failure(s) of other child process",
-                            i,
-                        )
-                        continue
-                    raise
-                children.append(p)
+                    except RuntimeError as e:
+                        if "loop stopped" in e.args[0]:
+                            log.warning(
+                                "skipping spawning of child[worker]:%d due to "
+                                "async failure(s) of other child process",
+                                i,
+                            )
+                            continue
+                        raise
+                    children.append(p)
 
-            # spawn extra workers
-            for i, f in enumerate(extra_procs):
-                try:
-                    p = main_loop.run_until_complete(
-                        afork(
+                # spawn extra workers
+                for i, f in enumerate(extra_procs):
+                    try:
+                        p = await afork(
                             functools.partial(
                                 _extra_main,
                                 f,
@@ -743,68 +689,57 @@ def start_server(
                             ),
                             mp_context=mp_context,
                         )
-                    )
-                except RuntimeError as e:
-                    if "loop stopped" in e.args[0]:
-                        log.warning(
-                            "skipping spawning of child[extra]:%d due to "
-                            "async failure(s) of other child process",
-                            num_workers + i,
-                        )
-                        continue
-                    raise
-                children.append(p)
+                    except RuntimeError as e:
+                        if "loop stopped" in e.args[0]:
+                            log.warning(
+                                "skipping spawning of child[extra]:%d due to "
+                                "async failure(s) of other child process",
+                                num_workers + i,
+                            )
+                            continue
+                        raise
+                    children.append(p)
 
-            write_pipe.close()
+                write_pipe.close()
 
-            # unblock the stop signals for user/external interrupts.
-            signal.pthread_sigmask(signal.SIG_UNBLOCK, sigblock_mask)
+                # unblock the stop signals for user/external interrupts.
+                signal.pthread_sigmask(signal.SIG_UNBLOCK, sigblock_mask)
 
-            # run!
-            try:
-                if not run_to_completion:
-                    main_loop.run_until_complete(main_future)
-                else:
-                    main_ctx.yield_return = _get_default_stop_signal(stop_signals)
-            except asyncio.CancelledError:
-                pass
-            finally:
-                # If interrupted or complete, wait for workers to finish.
+                # run!
                 try:
-                    worker_results: list[int | BaseException] = (
-                        main_loop.run_until_complete(
-                            asyncio.wait_for(
-                                asyncio.gather(
-                                    *[child.wait() for child in children],
-                                    return_exceptions=True,
-                                ),
-                                wait_timeout,
-                            )
+                    if not run_to_completion:
+                        await main_future
+                    else:
+                        main_ctx.yield_return = _get_default_stop_signal(stop_signals)
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    # If interrupted or complete, wait for workers to finish.
+                    try:
+                        worker_results: list[
+                            int | BaseException
+                        ] = await asyncio.wait_for(
+                            asyncio.gather(
+                                *[child.wait() for child in children],
+                                return_exceptions=True,
+                            ),
+                            wait_timeout,
                         )
-                    )
-                    for child, result in zip(children, worker_results):
-                        if isinstance(result, Exception):
-                            log.error(
-                                "Waiting for a child process [%d] has failed by an error.",
-                                child.pid,
-                                exc_info=result,
-                            )
-                except asyncio.TimeoutError:
-                    log.warning(
-                        "Timeout during waiting for child processes; killing all",
-                    )
-                    for child in children:
-                        child.send_signal(signal.SIGKILL)
-    finally:
-        main_loop.remove_reader(read_pipe.fileno())
-        read_pipe.close()
-        try:
-            main_loop.run_until_complete(cancel_all_tasks())
-            main_loop.run_until_complete(main_loop.shutdown_asyncgens())
-            try:
-                main_loop.run_until_complete(main_loop.shutdown_default_executor())
-            except (AttributeError, NotImplementedError):  # for uvloop
-                pass
+                        for child, result in zip(children, worker_results):
+                            if isinstance(result, Exception):
+                                log.error(
+                                    "Waiting for a child process [%d] has failed by an error.",
+                                    child.pid,
+                                    exc_info=result,
+                                )
+                    except asyncio.TimeoutError:
+                        log.warning(
+                            "Timeout during waiting for child processes; killing all",
+                        )
+                        for child in children:
+                            child.send_signal(signal.SIGKILL)
         finally:
-            main_loop.close()
-            asyncio.set_event_loop(None)
+            main_loop.remove_reader(read_pipe.fileno())
+            read_pipe.close()
+
+    asyncio.run(_parent_main())

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -584,16 +584,20 @@ def start_server(
 
     assert stop_signals
 
-    if hasattr(asyncio, "get_running_loop"):
-        # only for Python 3.7+
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            # there should be none.
-            pass
-        else:
-            raise RuntimeError(
-                "aiotools.start_server() cannot be called inside a running event loop."
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # there should be none.
+        pass
+    else:
+        raise RuntimeError(
+            "aiotools.start_server() cannot be called inside a running event loop."
+        )
+
+    if sys.version_info >= (3, 14):
+        if mp_context is not None and mp_context.get_start_method() == "fork":
+            raise NotImplementedError(
+                "In Python 3.14 or higher, the 'fork' start-method is no longer supported."
             )
 
     if main_ctxmgr is None:

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -567,6 +567,15 @@ def start_server(
 
         The **mp_context**, **prestart_hook**, **ignore_child_interrupts**,
         and **run_to_completion** arguments.
+
+    .. versionchanged:: 2.1.0
+
+       In Python 3.14 or higher, the "fork" mode support is REMOVED AND DISCOURAGED
+       as it causes silent hanging when combined with asyncio event loops.
+
+       Using custom stop signals with **extra_proc** is now STRONGLY DISCOURAGED
+       as it causes multiprocessing's resource tracker killed by them and
+       there is no way to control this behavior from our side.
     """
 
     @main_context

--- a/src/aiotools/taskcontext.py
+++ b/src/aiotools/taskcontext.py
@@ -145,6 +145,7 @@ class TaskContext:
         *,
         name: str | None = None,
         context: Context | None = None,
+        **kwargs: Any,
     ) -> asyncio.Task[T]:
         """
         Create a new task in this scope and return it.
@@ -160,7 +161,7 @@ class TaskContext:
                 "{type(self).__name__} must be used within a single parent task."
             )
         self._parent_task = parent_task
-        return self._create_task(coro, name=name, context=context)
+        return self._create_task(coro, name=name, context=context, **kwargs)
 
     def _create_task(
         self,
@@ -168,6 +169,7 @@ class TaskContext:
         *,
         name: str | None = None,
         context: Context | None = None,
+        **kwargs: Any,
     ) -> asyncio.Task[T]:
         assert self._loop is not None
         if self._aborting:
@@ -176,6 +178,7 @@ class TaskContext:
             coro,
             name=name,
             context=self._default_context if context is None else context,
+            **kwargs,
         )
         # optimization: Immediately call the done callback if the task is
         # already done (e.g. if the coro was able to complete eagerly),

--- a/src/aiotools/taskcontext.py
+++ b/src/aiotools/taskcontext.py
@@ -64,6 +64,12 @@ class TaskContext:
 
     If you provide ``context``, it will be passed to :meth:`create_task()` by default.
 
+    .. note::
+
+       Unlike :class:`~aiotools.taskscope.TaskScope`, TaskContext does not update
+       the callgraph introduced in Python 3.14 as it does not implement completion-based
+       waiting semantics but just grouped cancellation when explicitly requested.
+
     .. versionadded:: 2.0
     """
 

--- a/src/aiotools/taskgroup/persistent.py
+++ b/src/aiotools/taskgroup/persistent.py
@@ -31,7 +31,7 @@ __all__ = (
 current_ptaskgroup: ContextVar[PersistentTaskGroup] = ContextVar("current_ptaskgroup")  # type: ignore[deprecated]
 
 _ptaskgroup_idx = itertools.count()
-_log = logging.getLogger(__name__)
+_log = logging.getLogger(__spec__.name)
 _all_ptaskgroups: weakref.WeakSet[PersistentTaskGroup] = weakref.WeakSet()  # type: ignore[deprecated]
 
 T = TypeVar("T")

--- a/src/aiotools/taskscope.py
+++ b/src/aiotools/taskscope.py
@@ -185,6 +185,7 @@ class TaskScope(TaskContext):
         *,
         name: str | None = None,
         context: Context | None = None,
+        **kwargs: Any,
     ) -> tasks.Task[T]:
         """
         Create a new task in this scope and return it.
@@ -195,7 +196,7 @@ class TaskScope(TaskContext):
         if self._exiting and not self._tasks:
             raise RuntimeError(f"{type(self).__name__} {self!r} is finished")
         assert self._parent_task is not None
-        task = self._create_task(coro, name=name, context=context)
+        task = self._create_task(coro, name=name, context=context, **kwargs)
         if _has_callgraph:
             asyncio.future_add_to_awaited_by(task, self._parent_task)  # type: ignore[attr-defined]
         return task

--- a/src/aiotools/taskscope.py
+++ b/src/aiotools/taskscope.py
@@ -49,6 +49,12 @@ class TaskScope(TaskContext):
     alias of :class:`TaskScope` with ``exception_handler=None``.
 
     .. versionadded:: 2.0
+
+    .. versionchanged:: 2.1
+
+       In Python 3.14 or higher, it also updates :doc:`the asyncio call graph
+       <python:library/asyncio-graph>` so that the task awaiter could be tracked down
+       via TaskScope, like :class:`asyncio.TaskGroup`.
     """
 
     _tasks: set[asyncio.Task[Any]]

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -696,7 +696,7 @@ def test_cancel_and_wait_eager_tasks(use_eager_task_factory: bool) -> None:
     async def _test() -> None:
         if use_eager_task_factory:
             loop = asyncio.get_running_loop()
-            loop.set_task_factory(asyncio.eager_task_factory)
+            loop.set_task_factory(asyncio.eager_task_factory)  # type: ignore[attr-defined]
 
         task = asyncio.create_task(eager_task())
         await cancel_and_wait(task)

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -26,6 +26,18 @@ if sys.platform == "win32":
     )
 
 
+pidfd_params = [
+    pytest.param(False, id="posix"),
+    pytest.param(
+        True,
+        marks=pytest.mark.skipif(
+            not _has_pidfd,
+            reason="Your Python build does not support pidfd (supported in Python 3.9+ and Linux kernel 5.4+)",
+        ),
+        id="pidfd",
+    ),
+]
+
 target_mp_contexts = [
     pytest.param(mp.get_context(method), id=method)
     for method in mp.get_all_start_methods()
@@ -38,13 +50,21 @@ def child_for_fork() -> int:
     return 99
 
 
-async def _do_test_fork(mp_context: MPContext) -> None:
-    proc = await afork(child_for_fork, mp_context=mp_context)
-    assert proc.pid > 0
-    if isinstance(proc, PidfdChildProcess):
-        assert proc._pidfd > 0
-    ret = await proc.wait()
-    assert ret == 99
+@pytest.mark.parametrize("has_pidfd", pidfd_params)
+@pytest.mark.parametrize("mp_context", target_mp_contexts)
+@pytest.mark.asyncio
+async def test_fork(has_pidfd: bool, mp_context: MPContext) -> None:
+    with mock.patch.object(
+        fork_mod,
+        "_has_pidfd",
+        has_pidfd,
+    ):
+        proc = await afork(child_for_fork, mp_context=mp_context)
+        assert proc.pid > 0
+        if isinstance(proc, PidfdChildProcess):
+            assert proc._pidfd > 0
+        ret = await proc.wait()
+        assert ret == 99
 
 
 def child_for_fork_already_terminated() -> int:
@@ -52,14 +72,22 @@ def child_for_fork_already_terminated() -> int:
     return 99
 
 
-async def _do_test_fork_already_terminated(mp_context: MPContext) -> None:
-    proc = await afork(child_for_fork_already_terminated, mp_context=mp_context)
-    assert proc.pid > 0
-    if isinstance(proc, PidfdChildProcess):
-        assert proc._pidfd > 0
-    await asyncio.sleep(0.5)
-    ret = await proc.wait()
-    assert ret == 99
+@pytest.mark.parametrize("has_pidfd", pidfd_params)
+@pytest.mark.parametrize("mp_context", target_mp_contexts)
+@pytest.mark.asyncio
+async def test_fork_already_terminated(has_pidfd: bool, mp_context: MPContext) -> None:
+    with mock.patch.object(
+        fork_mod,
+        "_has_pidfd",
+        has_pidfd,
+    ):
+        proc = await afork(child_for_fork_already_terminated, mp_context=mp_context)
+        assert proc.pid > 0
+        if isinstance(proc, PidfdChildProcess):
+            assert proc._pidfd > 0
+        await asyncio.sleep(0.5)
+        ret = await proc.wait()
+        assert ret == 99
 
 
 def child_for_fork_signal() -> int:
@@ -70,17 +98,25 @@ def child_for_fork_signal() -> int:
     return 100
 
 
-async def _do_test_fork_signal(mp_context: MPContext) -> None:
-    os.setpgrp()
-    proc = await afork(child_for_fork_signal, mp_context=mp_context)
-    assert proc.pid > 0
-    if isinstance(proc, PidfdChildProcess):
-        assert proc._pidfd > 0
-    await asyncio.sleep(0.1)
-    proc.send_signal(signal.SIGINT)
-    ret = await proc.wait()
-    # FIXME: Sometimes it returns 254
-    assert ret == 101
+@pytest.mark.parametrize("has_pidfd", pidfd_params)
+@pytest.mark.parametrize("mp_context", target_mp_contexts)
+@pytest.mark.asyncio
+async def test_fork_signal(has_pidfd: bool, mp_context: MPContext) -> None:
+    with mock.patch.object(
+        fork_mod,
+        "_has_pidfd",
+        has_pidfd,
+    ):
+        os.setpgrp()
+        proc = await afork(child_for_fork_signal, mp_context=mp_context)
+        assert proc.pid > 0
+        if isinstance(proc, PidfdChildProcess):
+            assert proc._pidfd > 0
+        await asyncio.sleep(0.1)
+        proc.send_signal(signal.SIGINT)
+        ret = await proc.wait()
+        # FIXME: Sometimes it returns 254
+        assert ret == 101
 
 
 def child_for_fork_segfault() -> int:
@@ -91,14 +127,22 @@ def child_for_fork_segfault() -> int:
     return 0
 
 
-async def _do_test_fork_segfault(mp_context: MPContext) -> None:
-    os.setpgrp()
-    proc = await afork(child_for_fork_segfault, mp_context=mp_context)
-    assert proc.pid > 0
-    if isinstance(proc, PidfdChildProcess):
-        assert proc._pidfd > 0
-    ret = await proc.wait()
-    assert ret == -11  # SIGSEGV
+@pytest.mark.parametrize("has_pidfd", pidfd_params)
+@pytest.mark.parametrize("mp_context", target_mp_contexts)
+@pytest.mark.asyncio
+async def test_fork_segfault(has_pidfd: bool, mp_context: MPContext) -> None:
+    with mock.patch.object(
+        fork_mod,
+        "_has_pidfd",
+        has_pidfd,
+    ):
+        os.setpgrp()
+        proc = await afork(child_for_fork_segfault, mp_context=mp_context)
+        assert proc.pid > 0
+        if isinstance(proc, PidfdChildProcess):
+            assert proc._pidfd > 0
+        ret = await proc.wait()
+        assert ret == -11  # SIGSEGV
 
 
 def child_for_fork_many() -> int:
@@ -109,121 +153,29 @@ def child_for_fork_many() -> int:
     return 100
 
 
-async def _do_test_fork_many(mp_context: MPContext) -> None:
-    os.setpgrp()
-    proc_list: list[AbstractChildProcess] = []
-    for _ in range(32):
-        proc = await afork(child_for_fork_many, mp_context=mp_context)
-        proc_list.append(proc)
-        assert proc.pid > 0
-        if isinstance(proc, PidfdChildProcess):
-            assert proc._pidfd > 0
-    for i in range(16):
-        proc_list[i].send_signal(signal.SIGINT)
-    for i in range(16, 32):
-        proc_list[i].send_signal(signal.SIGTERM)
-    ret_list = await asyncio.gather(*[proc.wait() for proc in proc_list])
-    for i in range(16):
-        assert ret_list[i] == 101
-    for i in range(16, 32):
-        assert ret_list[i] == -15  # killed by SIGTERM
-
-
-@pytest.mark.skipif(
-    not _has_pidfd, reason="pidfd is supported in Python 3.9+ and Linux kernel 5.4+"
-)
+@pytest.mark.parametrize("has_pidfd", pidfd_params)
 @pytest.mark.parametrize("mp_context", target_mp_contexts)
 @pytest.mark.asyncio
-async def test_fork(mp_context: MPContext) -> None:
-    await _do_test_fork(mp_context)
-
-
-@pytest.mark.skipif(
-    not _has_pidfd, reason="pidfd is supported in Python 3.9+ and Linux kernel 5.4+"
-)
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_already_terminated(mp_context: MPContext) -> None:
-    await _do_test_fork_already_terminated(mp_context)
-
-
-@pytest.mark.skipif(
-    not _has_pidfd, reason="pidfd is supported in Python 3.9+ and Linux kernel 5.4+"
-)
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_signal(mp_context: MPContext) -> None:
-    await _do_test_fork_signal(mp_context)
-
-
-@pytest.mark.skipif(
-    not _has_pidfd, reason="pidfd is supported in Python 3.9+ and Linux kernel 5.4+"
-)
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_segfault(mp_context: MPContext) -> None:
-    await _do_test_fork_segfault(mp_context)
-
-
-@pytest.mark.skipif(
-    not _has_pidfd, reason="pidfd is supported in Python 3.9+ and Linux kernel 5.4+"
-)
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_many(mp_context: MPContext) -> None:
-    await _do_test_fork_many(mp_context)
-
-
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_fallback(mp_context: MPContext) -> None:
+async def test_fork_many(has_pidfd: bool, mp_context: MPContext) -> None:
     with mock.patch.object(
         fork_mod,
         "_has_pidfd",
-        False,
+        has_pidfd,
     ):
-        await _do_test_fork(mp_context)
-
-
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_already_termination_fallback(mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        False,
-    ):
-        await _do_test_fork_already_terminated(mp_context)
-
-
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_signal_fallback(mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        False,
-    ):
-        await _do_test_fork_signal(mp_context)
-
-
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_segfault_fallback(mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        False,
-    ):
-        await _do_test_fork_segfault(mp_context)
-
-
-@pytest.mark.parametrize("mp_context", target_mp_contexts)
-@pytest.mark.asyncio
-async def test_fork_many_fallback(mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        False,
-    ):
-        await _do_test_fork_many(mp_context)
+        os.setpgrp()
+        proc_list: list[AbstractChildProcess] = []
+        for _ in range(32):
+            proc = await afork(child_for_fork_many, mp_context=mp_context)
+            proc_list.append(proc)
+            assert proc.pid > 0
+            if isinstance(proc, PidfdChildProcess):
+                assert proc._pidfd > 0
+        for i in range(16):
+            proc_list[i].send_signal(signal.SIGINT)
+        for i in range(16, 32):
+            proc_list[i].send_signal(signal.SIGTERM)
+        ret_list = await asyncio.gather(*[proc.wait() for proc in proc_list])
+        for i in range(16):
+            assert ret_list[i] == 101
+        for i in range(16, 32):
+            assert ret_list[i] == -15  # killed by SIGTERM

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -29,7 +29,6 @@ if sys.platform == "win32":
 target_mp_contexts = [
     pytest.param(mp.get_context(method), id=method)
     for method in mp.get_all_start_methods()
-    if method != "forkserver"
 ]
 
 

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -54,11 +54,7 @@ def child_for_fork() -> int:
 @pytest.mark.parametrize("mp_context", target_mp_contexts)
 @pytest.mark.asyncio
 async def test_fork(has_pidfd: bool, mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        has_pidfd,
-    ):
+    with mock.patch.object(fork_mod, "_has_pidfd", has_pidfd):
         proc = await afork(child_for_fork, mp_context=mp_context)
         assert proc.pid > 0
         if isinstance(proc, PidfdChildProcess):
@@ -76,11 +72,7 @@ def child_for_fork_already_terminated() -> int:
 @pytest.mark.parametrize("mp_context", target_mp_contexts)
 @pytest.mark.asyncio
 async def test_fork_already_terminated(has_pidfd: bool, mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        has_pidfd,
-    ):
+    with mock.patch.object(fork_mod, "_has_pidfd", has_pidfd):
         proc = await afork(child_for_fork_already_terminated, mp_context=mp_context)
         assert proc.pid > 0
         if isinstance(proc, PidfdChildProcess):
@@ -102,11 +94,7 @@ def child_for_fork_signal() -> int:
 @pytest.mark.parametrize("mp_context", target_mp_contexts)
 @pytest.mark.asyncio
 async def test_fork_signal(has_pidfd: bool, mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        has_pidfd,
-    ):
+    with mock.patch.object(fork_mod, "_has_pidfd", has_pidfd):
         os.setpgrp()
         proc = await afork(child_for_fork_signal, mp_context=mp_context)
         assert proc.pid > 0
@@ -131,11 +119,7 @@ def child_for_fork_segfault() -> int:
 @pytest.mark.parametrize("mp_context", target_mp_contexts)
 @pytest.mark.asyncio
 async def test_fork_segfault(has_pidfd: bool, mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        has_pidfd,
-    ):
+    with mock.patch.object(fork_mod, "_has_pidfd", has_pidfd):
         os.setpgrp()
         proc = await afork(child_for_fork_segfault, mp_context=mp_context)
         assert proc.pid > 0
@@ -157,11 +141,7 @@ def child_for_fork_many() -> int:
 @pytest.mark.parametrize("mp_context", target_mp_contexts)
 @pytest.mark.asyncio
 async def test_fork_many(has_pidfd: bool, mp_context: MPContext) -> None:
-    with mock.patch.object(
-        fork_mod,
-        "_has_pidfd",
-        has_pidfd,
-    ):
+    with mock.patch.object(fork_mod, "_has_pidfd", has_pidfd):
         os.setpgrp()
         proc_list: list[AbstractChildProcess] = []
         for _ in range(32):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -499,7 +499,7 @@ def test_server_extra_proc_custom_stop_signal(
     restore_signal: None,
     mp_context: MPContext,
 ) -> None:
-    if getattr(mp_context, "_name", "default") in ("spawn", "forkserver"):
+    if mp_context.get_start_method() in ("spawn", "forkserver"):
         pytest.skip(
             "Custom stop signals with extra procs is not supported due to multiprocessing resource manager gets killed by them."
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import glob
+import logging
 import logging.config
 import multiprocessing as mp
 import os
@@ -16,6 +17,7 @@ from types import FrameType
 from typing import Any, Optional, Sequence
 
 import pytest
+from _pytest.mark.structures import ParameterSet
 
 import aiotools
 from aiotools.fork import MPContext
@@ -32,15 +34,18 @@ if sys.platform == "win32":
         allow_module_level=True,
     )
 
-target_mp_contexts = [
-    pytest.param(mp.get_context(method), id=method)
-    for method in mp.get_all_start_methods()
-]
-target_mp_contexts_without_forkserver = [
-    pytest.param(mp.get_context(method), id=method)
-    for method in mp.get_all_start_methods()
-    if method != "forkserver"
-]
+target_mp_contexts: list[ParameterSet] = []
+for method in mp.get_all_start_methods():
+    marks: list[pytest.MarkDecorator] = []
+    if method == "fork":
+        marks.append(
+            pytest.mark.skipif(
+                sys.version_info >= (3, 14),
+                reason="The start_method 'fork' is no longer supported in Python 3.14 or higher.",
+            )
+        )
+    param = pytest.param(mp.get_context(method), marks=marks, id=method)
+    target_mp_contexts.append(param)
 
 
 @pytest.fixture
@@ -488,12 +493,16 @@ def extra_proc_for_custom_stop_signal(
         received_signals[key] = e.args[0]
 
 
-@pytest.mark.parametrize("mp_context", target_mp_contexts_without_forkserver)
+@pytest.mark.parametrize("mp_context", target_mp_contexts)
 def test_server_extra_proc_custom_stop_signal(
     set_timeout: Callable[[float, Callable[..., None]], None],
     restore_signal: None,
     mp_context: MPContext,
 ) -> None:
+    if getattr(mp_context, "_name", "default") in ("spawn", "forkserver"):
+        pytest.skip(
+            "Custom stop signals with extra procs is not supported due to multiprocessing resource manager gets killed by them."
+        )
     # In local tests, the timeout may be as short as 0.x seconds,
     # but in GitHub Actions, we should assume more than 1 seconds of delay
     # for each worker process spawned.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,12 +22,6 @@ from _pytest.mark.structures import ParameterSet
 import aiotools
 from aiotools.fork import MPContext
 
-if os.environ.get("CI", "") and sys.version_info < (3, 9, 0):
-    pytest.skip(
-        "skipped to prevent kill CI agents due to signals on CI environments",
-        allow_module_level=True,
-    )
-
 if sys.platform == "win32":
     pytest.skip(
         "server tests not supported on Windows",

--- a/tests/test_taskscope.py
+++ b/tests/test_taskscope.py
@@ -71,7 +71,7 @@ async def test_taskscope_call_graph_support() -> None:
 
 
 @pytest.mark.asyncio
-async def test_TaskScope_partial_failure() -> None:
+async def test_taskscope_partial_failure() -> None:
     results: list[int] = []
     errors: list[BaseException] = []
     tasks: list[asyncio.Task[Any]] = []
@@ -91,7 +91,7 @@ async def test_TaskScope_partial_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_TaskScope_timeout_before_failure() -> None:
+async def test_taskscope_timeout_before_failure() -> None:
     results: list[int] = []
     errors: list[BaseException] = []
     cancelled = 0
@@ -119,7 +119,7 @@ async def test_TaskScope_timeout_before_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_TaskScope_timeout_after_failure() -> None:
+async def test_taskscope_timeout_after_failure() -> None:
     results: list[int] = []
     errors: list[BaseException] = []
     cancelled = 0

--- a/tests/test_taskscope.py
+++ b/tests/test_taskscope.py
@@ -41,7 +41,7 @@ async def test_taskscope_keep_running() -> None:
 
 @pytest.mark.skipif(
     sys.version_info < (3, 14),
-    reason="asynio callgraph is available in Python 3.14 or higher",
+    reason="asyncio callgraph requires Python 3.14 or higher",
 )
 @pytest.mark.asyncio
 async def test_taskscope_call_graph_support() -> None:
@@ -63,9 +63,11 @@ async def test_taskscope_call_graph_support() -> None:
         await parent_task
 
         assert graph is not None
-        assert len(graph.awaited_by) == 1  # TaskScope should chain the task awaiters
+        assert len(graph.awaited_by) == 1, "TaskScope should chain the task awaiters."
         parent_task = cast(asyncio.Task[None], graph.awaited_by[0].future)
-        assert parent_task.get_name() == "parent"
+        assert parent_task.get_name() == "parent", (
+            "the awaiter name should be 'parent', not 'Task-1' or something else."
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_taskscope.py
+++ b/tests/test_taskscope.py
@@ -70,6 +70,31 @@ async def test_taskscope_call_graph_support() -> None:
         )
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="per-task eagerness control is available in Python 3.14 or higher",
+)
+@pytest.mark.asyncio
+async def test_taskscope_create_task_passing_kwargs() -> None:
+    """
+    Passing arbitrary kwargs to create_task() methods is now allowed in Python 3.14.
+
+    In Python 3.14, we now have "eager_start=True" option to control individual
+    task's eagerness, so let's make a kwargs-passing test using it.
+    """
+    result_holder: list[str] = []
+
+    async def eager_task() -> None:
+        # No await - completes synchronously
+        result_holder.append("done")
+
+    async with TaskScope() as ts:
+        task = ts.create_task(eager_task(), eager_start=True)
+        # The task is already done if it is eagerly scheduled.
+        assert result_holder == ["done"]
+        assert task.done()
+
+
 @pytest.mark.asyncio
 async def test_taskscope_partial_failure() -> None:
     results: list[int] = []

--- a/tests/test_taskscope.py
+++ b/tests/test_taskscope.py
@@ -50,8 +50,8 @@ async def test_taskscope_call_graph_support() -> None:
     async def child() -> None:
         nonlocal graph
         print()
-        asyncio.print_call_graph()
-        graph = asyncio.capture_call_graph()
+        asyncio.print_call_graph()  # type: ignore[attr-defined]
+        graph = asyncio.capture_call_graph()  # type: ignore[attr-defined]
         await asyncio.sleep(1.0)
 
     async def parent() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ dev = [
     { name = "coverage" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pystack" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -30,6 +31,7 @@ dev = [
     { name = "coverage", specifier = ">=7.10.7" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pystack", specifier = ">=1.5.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -769,6 +771,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pystack"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/81/242c87b53cfca4cdea18878513bc0a19fa365bc0df372668cbbafb4c6863/pystack-1.5.1.tar.gz", hash = "sha256:9aa1a25ea2f1c3d2176059a280ef2f7c4e26c5540d37ed3c90ded65e6cc06f50", size = 102254, upload-time = "2025-08-18T20:59:50.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/ec/3cbc5f0fc670c72377eb6b098b0b09f4b05622687f4cc870a97462e56b6a/pystack-1.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9e033ebad9c0e6bd0e9160c31eb59e97fc670d99e85a7d8c9c8eba20ed4a4c", size = 7140363, upload-time = "2025-08-18T20:59:20.887Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f2/c851bf190b3af2e74539da0c9fe4512d9edc269ac34d16b64ebd49b7c0de/pystack-1.5.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9b7a8a6b815ef5b42102b97a91cbc8a071cd7b7c046732037509d636978d3b4", size = 6952370, upload-time = "2025-08-18T20:59:22.144Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d5/ad2fc95e350fe4b66cf8bccd424ee2128f2d987808ac8b9beeb506befce8/pystack-1.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8e619d52a3fc1614b7ffed90f16fc9e5cd6ab58d3117391c0e79d4d13584a8b", size = 8048632, upload-time = "2025-08-18T20:59:23.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/4c/5285221360436c94031bbbb33d14fa83b0656a692e5754a33bf14e29383c/pystack-1.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ec014e5765681c105c8140dbbd9ab8214b78f866284cfe6d6986767d7aa6d0ec", size = 7073983, upload-time = "2025-08-18T20:59:25.116Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ee/b4f1a0a7c429d5fa661a410446d54b1e829d35eedccf10f0c4a6f96025a8/pystack-1.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:644e75c8ecfbf7c9761aa6d2beff992f6bd140ae3aa4ff3a55887d1f79ee2962", size = 6893742, upload-time = "2025-08-18T20:59:26.376Z" },
+    { url = "https://files.pythonhosted.org/packages/12/98/d941f35cfc19fad8d49f7704de6644fb0ce6dca17f4c812652673f6b2215/pystack-1.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ce4f54b849ae956cbbdf27bce10254cafdaea76f7dd39971068b3ae10aafab6", size = 7985654, upload-time = "2025-08-18T20:59:27.887Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/84/393129226fc4ebcc738b73a6777f3cc860069faf1e9d4235dc3287a40191/pystack-1.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:48686d108054533a79c812eaf652fc00919c056706b321cd91fcc5749b3c2783", size = 7073031, upload-time = "2025-08-18T20:59:29.22Z" },
+    { url = "https://files.pythonhosted.org/packages/92/26/5481d2cc541c700a16aa2c75bcb8f8407eccb116435cee4b0f13e4708a07/pystack-1.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e707c784b53235fb8b2fa6024afe4d90a9c1c97edb7fdc64e4a6d009454bf5", size = 6894895, upload-time = "2025-08-18T20:59:30.565Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3b/640ebe51dce55c8395d71a91a895a3cae9906f8a276c6ae5e9b724239e92/pystack-1.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da9498c47f80e4d4dc9bdbf123499d33d78530f5959560140447ddf92af60c1b", size = 7987056, upload-time = "2025-08-18T20:59:31.935Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/dd87e2259352581865916e1ea1db400b24a383ed15dd3e1def2872754fc4/pystack-1.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8028a87485760f4a4503c3f87861053e9d4f64143614b17104a808f53424adb6", size = 7060215, upload-time = "2025-08-18T20:59:33.589Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d7/a920e11ce1bcedd5d35ff471fb32134412f4781e94180a4beae5b5fd2f8c/pystack-1.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edceccf3308eeb36c7719a50733a400e3fa009aec00d46aadcb6475939c3fb7", size = 6884822, upload-time = "2025-08-18T20:59:34.98Z" },
+    { url = "https://files.pythonhosted.org/packages/92/27/10939f939a6c725c69e7115b067f0099065b34a0f8fd55fc5497ef423226/pystack-1.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:688318a839795b59338f81c8de205420de3eb0bd64e8482048a2d70f41e4ea7d", size = 7973011, upload-time = "2025-08-18T20:59:36.265Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/60/c477a065a226a7a3c8aa81cc882d3fd9281b6f431412de6e9dd6ec19f907/pystack-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:07c1e01e710ecbf2ccda0a81dde005970fe67466431498e44fbf853808d5b902", size = 7033856, upload-time = "2025-08-18T20:59:37.564Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2a/270bdcd214d8a79189fff910dfe9d1fa68502f278335b16ece41d6ac6b31/pystack-1.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d534d177b9b88a995294ba330cae4ea53ed9168802bb1efeb8b38a302018e6ad", size = 6883264, upload-time = "2025-08-18T20:59:39.188Z" },
+    { url = "https://files.pythonhosted.org/packages/59/65/157d26eb56aff4d6ea725f7f193a53b92b63f06081a52b462af8bd136d9c/pystack-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4de406ba67b132a86a801cc8ec29ec4c7a4d2867a66058b314f760960efc81b6", size = 7937342, upload-time = "2025-08-18T20:59:40.538Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "sys_platform == 'linux'",
+    "sys_platform != 'linux'",
+]
 
 [[package]]
 name = "aiotools"
@@ -11,7 +15,7 @@ dev = [
     { name = "coverage" },
     { name = "mypy" },
     { name = "pre-commit" },
-    { name = "pystack" },
+    { name = "pystack", marker = "sys_platform == 'linux'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -31,7 +35,7 @@ dev = [
     { name = "coverage", specifier = ">=7.10.7" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
-    { name = "pystack", specifier = ">=1.5.1" },
+    { name = "pystack", marker = "sys_platform == 'linux'", specifier = ">=1.5.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -85,7 +89,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -305,7 +309,7 @@ name = "cryptography"
 version = "46.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/9b/e301418629f7bfdf72db9e80ad6ed9d1b83c487c471803eaa6464c511a01/cryptography-46.0.2.tar.gz", hash = "sha256:21b6fc8c71a3f9a604f028a329e5560009cc4a3a828bfea5fcba8eb7647d88fe", size = 749293, upload-time = "2025-10-01T00:29:11.856Z" }
 wheels = [
@@ -1006,8 +1010,8 @@ name = "secretstorage"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform == 'linux'" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/9f/11ef35cf1027c1339552ea7bfe6aaa74a8516d8b5caf6e7d338daf54fd80/secretstorage-3.4.0.tar.gz", hash = "sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c", size = 19748, upload-time = "2025-09-09T16:42:13.859Z" }
 wheels = [


### PR DESCRIPTION
* [x] Basic compatibility with 3.14 including CI
* [x] **BREAKING:** Deprecate/discourage use of "fork" start-method of multiprocessing with fork/server modules as it causes indefinite, silent hanging due to asyncio context conflicts
  - In Python 3.14, "forkserver" became the default for POSIX platforms and it works well.
  - Using custom stop signals is not supported in general because multiprocessing's resource tracker gets killed by them and there is NO WAY to control this.
* [x] asyncio's new call-graph integration for TaskScope
  - https://docs.python.org/3/library/asyncio-graph.html#low-level-utility-functions
* [x] Allow arbitrary keyword arguments in `create_task()` methods, enabling use of `eager_start=True` option
  - https://docs.python.org/3/whatsnew/3.14.html#asyncio

### Additional Fixes
* Now `afork()` correctly returns the exit code of child processes that have terminated earlier than its first `waitid()` call in the forkserver mode.