### PR TITLE
fix: Handle uncancelled task termination in cancel_and_wait()

### DIFF
--- a/changes/92.fix.md
+++ b/changes/92.fix.md
@@ -1,0 +1,1 @@
+Treat explicitly uncancelled termination as a non-error in `cancel_and_wait()`

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -88,6 +88,7 @@ async def test_cancel_swallowed() -> None:
         await cancel_and_wait(task)
         assert task.done()
         assert not task.cancelled()
+        assert result_holder == ["start", "cancelling", "swallowed"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
See the docs:
https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancel

> Should the coroutine nevertheless decide to suppress the cancellation, it needs to call [Task.uncancel()](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.uncancel) in addition to catching the exception.

Refer to:
https://github.com/python/cpython/issues/103486#issuecomment-3389328895
