### PR TITLE
fix: Ensure consistency when nesting and mixing TaskScope/TaskGroup with shield options

### DIFF
--- a/changes/93.fix.md
+++ b/changes/93.fix.md
@@ -1,0 +1,1 @@
+Ensure consistency when nesting and mixing `aiotools.TaskScope` and `asyncio.TaskGroup` with different shield options and reimplement `ShieldScope` based on the improved `TaskScope`

--- a/src/aiotools/__init__.py
+++ b/src/aiotools/__init__.py
@@ -6,7 +6,6 @@ from importlib.metadata import version
 __version__ = version("aiotools")
 
 from .cancel import (
-    ShieldScope,
     cancel_and_wait,
 )
 from .compat import (
@@ -68,6 +67,7 @@ from .taskgroup import (
     current_taskgroup,
 )
 from .taskscope import (
+    ShieldScope,
     TaskScope,
     move_on_after,
 )
@@ -96,7 +96,6 @@ main = main_context
 
 __all__ = (
     # .cancel
-    "ShieldScope",
     "cancel_and_wait",
     # .compat
     "all_tasks",
@@ -155,6 +154,7 @@ __all__ = (
     "current_ptaskgroup",
     # .taskscope
     "TaskScope",
+    "ShieldScope",
     "move_on_after",
     # .timeouts
     "Timeout",

--- a/src/aiotools/utils.py
+++ b/src/aiotools/utils.py
@@ -71,7 +71,6 @@ async def as_completed_safe(
                 # CancelledError: injected when a timeout occurs
                 #                 (i.e., the outer scope cancels the inner)
                 # BaseException: injected when the process is going to terminate
-                await ts.aclose()
                 raise
 
 


### PR DESCRIPTION
Now we can mix and nest arbitrary depths of `aiotools.TaskScope` and `asyncio.TaskGroup` with different shield options. (Note that `asyncio.TaskGroup` does not have the shield option.)

Cancelling the outmost task is shielded by the topmost TaskScope having `shield=True`.
`ShieldScope` is now equivalent to `TaskScope(shield=True)` but comes with an optional feature to use it as a non-async context manager. In this mode, spawning child tasks is not allowed.

## Implementation details

* `TaskScope`
  - It now keeps track of parent-child relationship of scopes within a single task.
    - It borrows some ideas from [anyio](http://github.com/agronholm/anyio/) for this part.
    - To prevent confusion, `_parent_task` in `TaskContext` and `TaskScope` is renamed to `_host_task`, following anyio's convention.
  - It now correctly *responds* to the cancellations injected by `asyncio.timeout()` (only compatible for Python 3.13+).
  - The `shield` option
    - It ensures the topmost shield scope shields all inner scopes: both subtasks and the code blocks within the context managers.
    - Cancelling the host task is deferred by overriding `Task.cancel()`, `Task.uncancel()`, and `Task.cancelling()` methods and synchronizing cancellation requests upwards upon `__aexit__()`.
      - This is a little bit hacky approach, but without overriding `Task`, it is impossible to implement the shield concept as a context-manager as we don't have fine-grained control to prevent/inject cancellations for a task. For example, `Task._must_cancel` flag is highly specific to the asyncio internals. We don't try to manipulate it directly but just replaces the methods at runtime to "reroute" cancellation requests.
      - Overlapped overriding is safe because it is guaranteed to have only a single task scope active at a moment from the POV of user codes, as being nested context managers.
      - It transparently chains the choice of deferring cancellation operations or delegating them to the outer scope until it reaches the host task.
      - If we could directly patch the stdlib asyncio (python/cpython#105011), this hacky approach could be eliminated as we can directly modify the Task implementation.
    - When there is an injected cancellation, `__axit__()` queries whether there is an outer shield scope and suppresses the cancellation so that the code block within the scope continues.
    - Although `asyncio.TaskGroup` is not aware of the above machanisms, it mingles with `TaskScope` transparently because it does not have its own `shield` option and `TaskScope` overrides `asyncio.Task`'s cancellation methods.
* `ShieldScope` subclasses `TaskScope`.
  - It may be used as either an async context manager (`async with`) or a context manager (`with`).
  - When used as a context manager, it does not allow creating child tasks because there is no way to wait for their completion when (synchronously) exiting the scope.
* `utils.as_completed_safe()`
  - It no longer calls `TaskScope.aclose()` directly but just raises up `GeneratorExit` and `BaseException` to match with the above changes.