### PR TITLE
fix: Use weak key dict to store per-task custom states

### DIFF
--- a/changes/95.fix.md
+++ b/changes/95.fix.md
@@ -1,0 +1,1 @@
+Use weak key dict to prevent memroy leak when storing task states by task scopes

--- a/src/aiotools/taskscope.py
+++ b/src/aiotools/taskscope.py
@@ -15,6 +15,7 @@ from typing import (
     TypeGuard,
     TypeVar,
 )
+from weakref import WeakKeyDictionary
 
 from .taskcontext import ErrorCallback, LoopExceptionHandler, TaskContext
 from .types import CoroutineLike, OptExcInfo
@@ -33,7 +34,7 @@ class _TaskState:
     task_scope: TaskScope | None
 
 
-_task_states: dict[asyncio.Task[Any], _TaskState] = {}
+_task_states: WeakKeyDictionary[asyncio.Task[Any], _TaskState] = WeakKeyDictionary()
 _has_callgraph: Final = hasattr(asyncio, "future_add_to_awaited_by")
 
 


### PR DESCRIPTION
Prevent memory leak when storing per-task states such as the currently active task scope
