### PR TITLE
fix: Use thread-local storage for global per-task states

### DIFF
--- a/changes/96.fix.md
+++ b/changes/96.fix.md
@@ -1,0 +1,1 @@
+Use thread-local storage to store per-task states and avoid lock contention in free-threaded builds


### PR DESCRIPTION
- It's important to avoid lock contention in free-threaded builds
  in Python 3.14.
