### PR TITLE
fix: Prevent busy-loop and hang when all workers die abruptly

### DIFF
--- a/changes/102.fix.md
+++ b/changes/102.fix.md
@@ -1,0 +1,1 @@
+Fix `start_server()` busy-looping on a CPU core and hanging forever when all worker processes terminate without notifying the main program via the interrupt channel, such as when they are SIGKILLed or OOM-killed

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -50,6 +50,7 @@ from typing import Any, ParamSpec, TypeVar
 
 from .context import AbstractAsyncContextManager
 from .fork import AbstractChildProcess, MPContext, afork
+from .utils import gather_safe
 
 __all__ = (
     "main_context",
@@ -272,6 +273,13 @@ def main_context(
         return ServerMainContextManager(func, args, kwargs)
 
     return helper
+
+
+def _get_signal_name(signum: int) -> str:
+    try:
+        return signal.Signals(signum).name
+    except ValueError:
+        return str(signum)
 
 
 def _get_default_stop_signal(
@@ -671,23 +679,15 @@ def start_server(
         wait_all_children: asyncio.Task[list[int | BaseException]] | None = None
 
         async def wait_all_children_termination() -> list[int | BaseException]:
-            return await asyncio.gather(
-                *[child.wait() for child in children],
-                return_exceptions=True,
-            )
-
-        def handle_all_children_termination(
-            fut: asyncio.Task[list[int | BaseException]],
-        ) -> None:
-            if fut.cancelled() or run_to_completion:
-                return
-            if not main_future.done():
+            results = await gather_safe([child.wait() for child in children])
+            if not run_to_completion and not main_future.done():
                 log.warning(
                     "All child processes have terminated; "
                     "shutting down the main program.",
                 )
                 main_ctx.yield_return = _get_default_stop_signal(stop_signals)
                 main_future.cancel()
+            return results
 
         # start
         try:
@@ -760,7 +760,6 @@ def start_server(
                     wait_all_children = asyncio.create_task(
                         wait_all_children_termination()
                     )
-                    wait_all_children.add_done_callback(handle_all_children_termination)
 
                 # unblock the stop signals for user/external interrupts.
                 signal.pthread_sigmask(signal.SIG_UNBLOCK, sigblock_mask)
@@ -785,11 +784,28 @@ def start_server(
                             else []
                         )
                         for child, result in zip(children, worker_results):
-                            if isinstance(result, Exception):
+                            if isinstance(result, BaseException):
                                 log.error(
                                     "Waiting for a child process [%d] has failed by an error.",
                                     child.pid,
                                     exc_info=result,
+                                )
+                            elif result < 0:
+                                # A negative return code means that the child was
+                                # killed by the signal of its absolute value,
+                                # which the child could not handle by itself
+                                # (e.g., SIGKILL by the OOM killer).
+                                log.warning(
+                                    "A child process [%d] was terminated by the signal %s.",
+                                    child.pid,
+                                    _get_signal_name(-result),
+                                )
+                            elif result > 0:
+                                log.warning(
+                                    "A child process [%d] has exited with a non-zero "
+                                    "status %d.",
+                                    child.pid,
+                                    result,
                                 )
                     except asyncio.TimeoutError:
                         log.warning(

--- a/src/aiotools/server.py
+++ b/src/aiotools/server.py
@@ -647,8 +647,13 @@ def start_server(
         def handle_child_interrupt(read_pipe: mpconn.Connection) -> None:
             try:
                 child_idx: int = struct.unpack("i", read_pipe.recv_bytes(4))[0]
-            except EOFError:
-                # read_pipe is already closed
+            except (EOFError, OSError):
+                # All writer ends of the pipe are closed (i.e., all workers have
+                # terminated) or the pipe itself is already closed.
+                # We MUST unregister the reader here because the event loop's
+                # selector is level-triggered: an EOF'd fd is reported as readable
+                # on every iteration, which would busy-loop this callback forever.
+                main_loop.remove_reader(read_pipe.fileno())
                 return
             if not ignore_child_interrupts and not run_to_completion:
                 # self-interrupt to initiate the main-to-worker interrupts
@@ -658,6 +663,31 @@ def start_server(
 
         read_pipe, write_pipe = mp.Pipe()
         main_loop.add_reader(read_pipe.fileno(), handle_child_interrupt, read_pipe)
+
+        # Watches termination of all children to avoid the main program from
+        # hanging forever as a zombie supervisor when all children are gone,
+        # e.g., when they are SIGKILLed or OOM-killed without a chance to notify
+        # the main program via the interrupt channel.
+        wait_all_children: asyncio.Task[list[int | BaseException]] | None = None
+
+        async def wait_all_children_termination() -> list[int | BaseException]:
+            return await asyncio.gather(
+                *[child.wait() for child in children],
+                return_exceptions=True,
+            )
+
+        def handle_all_children_termination(
+            fut: asyncio.Task[list[int | BaseException]],
+        ) -> None:
+            if fut.cancelled() or run_to_completion:
+                return
+            if not main_future.done():
+                log.warning(
+                    "All child processes have terminated; "
+                    "shutting down the main program.",
+                )
+                main_ctx.yield_return = _get_default_stop_signal(stop_signals)
+                main_future.cancel()
 
         # start
         try:
@@ -726,6 +756,12 @@ def start_server(
 
                 write_pipe.close()
 
+                if children:
+                    wait_all_children = asyncio.create_task(
+                        wait_all_children_termination()
+                    )
+                    wait_all_children.add_done_callback(handle_all_children_termination)
+
                 # unblock the stop signals for user/external interrupts.
                 signal.pthread_sigmask(signal.SIG_UNBLOCK, sigblock_mask)
 
@@ -739,15 +775,14 @@ def start_server(
                     pass
                 finally:
                     # If interrupted or complete, wait for workers to finish.
+                    # Reuse the already-running watcher task instead of calling
+                    # child.wait() again, as concurrent waiters on the same child
+                    # may lose the exit code to each other.
                     try:
-                        worker_results: list[
-                            int | BaseException
-                        ] = await asyncio.wait_for(
-                            asyncio.gather(
-                                *[child.wait() for child in children],
-                                return_exceptions=True,
-                            ),
-                            wait_timeout,
+                        worker_results: list[int | BaseException] = (
+                            await asyncio.wait_for(wait_all_children, wait_timeout)
+                            if wait_all_children is not None
+                            else []
                         )
                         for child, result in zip(children, worker_results):
                             if isinstance(result, Exception):
@@ -763,6 +798,8 @@ def start_server(
                         for child in children:
                             child.send_signal(signal.SIGKILL)
         finally:
+            if wait_all_children is not None and not wait_all_children.done():
+                wait_all_children.cancel()
             main_loop.remove_reader(read_pipe.fileno())
             read_pipe.close()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,6 @@ import logging
 import logging.config
 import multiprocessing as mp
 import os
-import resource
 import signal
 import sys
 import tempfile
@@ -561,14 +560,14 @@ def test_server_all_workers_killed(
     # Safety net: if the fix regresses, this keeps the test from hanging forever.
     set_timeout(20.0, functools.partial(interrupt, signum=signal.SIGTERM))
     begin_wall = time.monotonic()
-    begin_cpu = sum(resource.getrusage(resource.RUSAGE_SELF)[:2])
+    begin_cpu = time.process_time()
     aiotools.start_server(
         myserver_self_sigkill,
         num_workers=2,
         mp_context=mp_context,
     )
     elapsed_wall = time.monotonic() - begin_wall
-    elapsed_cpu = sum(resource.getrusage(resource.RUSAGE_SELF)[:2]) - begin_cpu
+    elapsed_cpu = time.process_time() - begin_cpu
 
     # It should have returned on its own, well before the safety net fired.
     assert elapsed_wall < 10.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ import logging
 import logging.config
 import multiprocessing as mp
 import os
+import resource
 import signal
 import sys
 import tempfile
@@ -528,3 +529,49 @@ def test_server_extra_proc_custom_stop_signal(
     # so there is nothing we can do here. :(
     assert received_signals[0] == signal.SIGUSR1
     assert received_signals[1] == signal.SIGUSR1
+
+
+@aiotools.server_context
+async def myserver_self_sigkill(
+    loop: asyncio.AbstractEventLoop,
+    proc_idx: int,
+    args: Sequence[Any],
+) -> AsyncGenerator[None, signal.Signals]:
+    async def die() -> None:
+        await asyncio.sleep(0.5)
+        # SIGKILL bypasses _worker_main's exception handler, so the
+        # worker-to-main interrupt byte is never sent -- just like an OOM-kill.
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    task = asyncio.create_task(die())
+    yield
+    task.cancel()
+
+
+@pytest.mark.parametrize("mp_context", target_mp_contexts)
+def test_server_all_workers_killed(
+    set_timeout: Callable[[float, Callable[..., None]], None],
+    restore_signal: None,
+    mp_context: MPContext,
+) -> None:
+    # When all workers die without notifying the main program via the
+    # interrupt channel, the main program should shut down by itself instead of
+    # hanging forever while busy-looping on the EOF'd interrupt channel.
+
+    # Safety net: if the fix regresses, this keeps the test from hanging forever.
+    set_timeout(20.0, functools.partial(interrupt, signum=signal.SIGTERM))
+    begin_wall = time.monotonic()
+    begin_cpu = sum(resource.getrusage(resource.RUSAGE_SELF)[:2])
+    aiotools.start_server(
+        myserver_self_sigkill,
+        num_workers=2,
+        mp_context=mp_context,
+    )
+    elapsed_wall = time.monotonic() - begin_wall
+    elapsed_cpu = sum(resource.getrusage(resource.RUSAGE_SELF)[:2]) - begin_cpu
+
+    # It should have returned on its own, well before the safety net fired.
+    assert elapsed_wall < 10.0
+    # A busy-loop on the EOF'd interrupt channel would burn CPU time
+    # proportional to the wall time; a healthy main loop stays near zero.
+    assert elapsed_cpu < elapsed_wall / 2


### PR DESCRIPTION
## Problem

When every worker process terminates *without* writing the crash-interrupt byte — SIGKILL, OOM-kill, or any other uncatchable death — the parent process pins a CPU core at 100% and never exits.

Field diagnosis from a downstream project running aiotools 2.2.3:

- `pystack`: main thread repeatedly dispatching `handle_child_interrupt` → `recv_bytes`
- `strace`: `epoll_wait` returning `EPOLLIN|EPOLLHUP` instantly, `read() = 0` (EOF), in a tight infinite loop
- `ss`: the socketpair's peer end is destroyed (peer inode 0), parent is the sole remaining holder

### Root cause

The worker-to-main interrupt channel's write end is held only by the parent (closed in `start_server()` right after spawning) and by each worker (`_worker_main`'s `finally: intr_write_pipe.close()`). A SIGKILL runs neither that `finally` nor the exception handler that would send the interrupt byte, so once the last worker dies the kernel drops the refcount to zero and the read end sees EOF.

`handle_child_interrupt()` caught the resulting `EOFError` and simply returned, leaving the fd registered via `add_reader()`. The event loop's selector is **level-triggered**, so an EOF'd fd is reported readable on *every* iteration → the dead callback re-runs forever. Meanwhile `main_future` is never resolved, so the parent idles as a zombie supervisor.

## Fix

1. **Stop the spin** — the EOF branch now calls `main_loop.remove_reader()` before returning.
2. **Stop the hang** — a watcher task observes termination of *all* children and cancels `main_future` so the main program shuts down cleanly.
3. **Make it diagnosable** — children that did not exit cleanly are now logged: a negative return code means termination by an uncatchable signal (reported by name, e.g. `SIGKILL`), which is exactly the situation that used to hang silently. Normal shutdowns return 0, so this adds no noise.

Detection for (2) is deliberately based on the children rather than on the pipe EOF. The EOF's meaning varies by start method: under `fork`, extra procs inherit the write-end fd and hold it open; under `spawn` they never receive it, so EOF would fire while extra procs are still running. Watching `children` covers managed workers and extra procs uniformly.

The watcher task is also reused by the shutdown path instead of calling `child.wait()` a second time, since concurrent waiters on the same child can lose the exit code to each other.

### Notes on the watcher's implementation

**Uses `gather_safe()` rather than `asyncio.gather(..., return_exceptions=True)`.** When the watcher is cancelled — either by the outer `finally` or by a `wait_timeout` expiry — plain `gather()` propagates the cancellation to its children but does not await them. `child.wait()` performs `self._proc.join()` after its `waitpid` polling loop, so being left half-cancelled can skip that cleanup. `gather_safe()` wraps them in a `TaskScope` that guarantees termination. No import cycle: `utils` → `taskscope` → `taskcontext`/`types`.

**Deliberately not a `TaskGroup`/`TaskScope` for the watcher itself.** Structured scopes join their tasks on exit, but the watcher by definition does not complete until every child is dead, so `async with` would block on exit and still require an explicit `cancel()` — the scope buys nothing while adding a nesting level. Its lifetime also crosses the `with main_ctx` boundary: created inside, consumed with a timeout in the inner `finally`, cleaned up in the outer one. The task-GC-loss concern that scopes address is already covered by the strong reference in `wait_all_children`.

The cancellation logic lives in the coroutine body instead of an `add_done_callback`, which makes the `fut.cancelled()` check unnecessary — a cancelled watcher never reaches that code.

## Test

`test_server_all_workers_killed` spawns workers that self-SIGKILL, then asserts the parent returns on its own (with a signal-based safety net so a regression fails rather than hangs) and that its consumed CPU time — via `time.process_time()` — stays well below the wall time, which catches the busy-loop specifically, not just the hang.

Verified failing against the pre-fix `server.py`:

```
>       assert elapsed_wall < 10.0
E       assert 20.00081063603284 < 10.0
FAILED tests/test_server.py::test_server_all_workers_killed[forkserver]
FAILED tests/test_server.py::test_server_all_workers_killed[spawn]
```

and passing after. Full suite (180 passed / 13 skipped) and `pre-commit run -a` (ruff + mypy) are clean; CI is green across Linux/macOS/Windows × 3.11–3.14t.

https://claude.ai/code/session_01Jh2hyxc8MRZdJ8SJiL5sAD